### PR TITLE
add control plane client to traffic controller

### DIFF
--- a/main.go
+++ b/main.go
@@ -94,7 +94,7 @@ func main() {
 	if err = (&secret.SecretReconciler{
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
-		MCWatch: &multiClusterWatch.WatchController{Manager: mgr, HandlerFactory: multiClusterWatch.NewIngressHandlerFactory()},
+		MCWatch: &multiClusterWatch.WatchController{Manager: mgr, HandlerFactory: multiClusterWatch.NewTrafficHandlerFactory()},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Secret")
 		os.Exit(1)

--- a/pkg/controllers/traffic/traffic_controller.go
+++ b/pkg/controllers/traffic/traffic_controller.go
@@ -30,12 +30,13 @@ import (
 	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/traffic"
 )
 
-// IngressReconciler reconciles an Ingress object
-type IngressReconciler struct {
-	client.Client
+// Reconciler reconciles a traffic object
+type Reconciler struct {
+	WorkloadClient client.Client
+	ControlClient  client.Client
 }
 
-func (r *IngressReconciler) Handle(ctx context.Context, o runtime.Object) (ctrl.Result, error) {
+func (r *Reconciler) Handle(ctx context.Context, o runtime.Object) (ctrl.Result, error) {
 	_ = log.FromContext(ctx)
 
 	trafficAccessor := o.(traffic.Interface)
@@ -50,7 +51,7 @@ func (r *IngressReconciler) Handle(ctx context.Context, o runtime.Object) (ctrl.
 
 	cm := &corev1.ConfigMap{}
 
-	err := r.Client.Get(ctx, client.ObjectKey{Namespace: trafficAccessor.GetNamespace(), Name: cmName}, cm)
+	err := r.WorkloadClient.Get(ctx, client.ObjectKey{Namespace: trafficAccessor.GetNamespace(), Name: cmName}, cm)
 	if err != nil {
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
This should ultimately be replaced with a service account client, but for now this will unblock development.