### PR TITLE
Update ingress nginx config

### DIFF
--- a/config/ingress-nginx/kustomization.yaml
+++ b/config/ingress-nginx/kustomization.yaml
@@ -18,6 +18,8 @@ helmCharts:
         hostNetwork: true
         ingressClassResource:
           default: true
+        publishService:
+          enabled: false
         reportNodeInternalIp: true
         service:
           type: NodePort

--- a/samples/echo-service/echo.yaml
+++ b/samples/echo-service/echo.yaml
@@ -39,7 +39,7 @@ metadata:
   name: echo
 spec:
   rules:
-    - host: "echo.127.0.0.1.nip.io"
+    - host: ""
       http:
         paths:
           - path: /


### PR DESCRIPTION
Disable the publish service feature which prevents the `reportNodeInternalIp` option working in local development. Without this option the internal cluster ip is used in the lb status preventing it being accessible outside of the cluster from the host.

```
$ make local-setup

$ kubectl apply -f samples/echo-service/echo.yaml 
service/echo created
deployment.apps/echo created
ingress.networking.k8s.io/echo created

$ kubectl get ingress echo -o json -w | jq .status.loadBalancer.ingress[0].ip
null
"172.18.0.2"

$ curl http://172.18.0.2
Request served by echo-7df5ffcf44-fnmzz

GET / HTTP/1.1

Host: 172.18.0.2
Accept: */*
User-Agent: curl/7.79.1
X-Forwarded-For: 172.18.0.1
X-Forwarded-Host: 172.18.0.2
X-Forwarded-Port: 80
X-Forwarded-Proto: http
X-Forwarded-Scheme: http
X-Real-Ip: 172.18.0.1
X-Request-Id: fbb9d7f564d21131fc72e277e1ea96cb
X-Scheme: http
```