### PR TITLE
Add lint ci check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.adoc'
+      - '**.md'
+      - 'samples/**'
+      - 'LICENSE'
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '**.adoc'
+      - '**.md'
+      - 'samples/**'
+      - 'LICENSE'
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: v1.19
+      - uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.49.0
+          only-new-issues: true
+          args: --timeout=5m
+          skip-go-installation: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,5 @@
+# https://golangci-lint.run/usage/linters/
+linters:
+  enable:
+    - gofmt
+    - misspell

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,7 @@ RUN go mod download
 
 # Copy the go source
 COPY main.go main.go
-COPY api/ api/
-COPY pkg/controllers/ controllers/
+COPY pkg/ pkg/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,10 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
+.PHONY: lint
+lint: ## Run golangci-lint against code.
+	golangci-lint run ./...
+
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out

--- a/hack/local-setup.sh
+++ b/hack/local-setup.sh
@@ -101,7 +101,5 @@ kindCreateCluster $KIND_CLUSTER_CONTROL_PLANE $port80 $port443
 deployIngressController $KIND_CLUSTER_CONTROL_PLANE
 #3. Deploy cert manager
 deployCertManager $KIND_CLUSTER_CONTROL_PLANE
-#4. Deploy external dns
-deployExternalDNS $KIND_CLUSTER_CONTROL_PLANE
-#5. Deploy argo cd
+#4. Deploy argo cd
 deployArgoCD $KIND_CLUSTER_CONTROL_PLANE

--- a/pkg/multiClusterWatch/main.go
+++ b/pkg/multiClusterWatch/main.go
@@ -96,11 +96,11 @@ func (w *ClusterWatcher) Start(ctx context.Context) error {
 			current := obj.(*networkingv1.Ingress)
 			target := current.DeepCopy()
 			targetAccessor := traffic.NewIngress(target)
-			w.Handler.Handle(ctx, targetAccessor)
+			_, _ = w.Handler.Handle(ctx, targetAccessor)
 			//todo handle requeue and errors
 			if !equality.Semantic.DeepEqual(current, target) {
 				//write back to cluster
-				w.client.NetworkingV1().Ingresses(target.Namespace).Update(ctx, target, metav1.UpdateOptions{})
+				_, _ = w.client.NetworkingV1().Ingresses(target.Namespace).Update(ctx, target, metav1.UpdateOptions{})
 			}
 		},
 		UpdateFunc: func(old, obj interface{}) {
@@ -108,11 +108,11 @@ func (w *ClusterWatcher) Start(ctx context.Context) error {
 			current := obj.(*networkingv1.Ingress)
 			target := current.DeepCopy()
 			targetAccessor := traffic.NewIngress(target)
-			w.Handler.Handle(ctx, targetAccessor)
+			_, _ = w.Handler.Handle(ctx, targetAccessor)
 			//todo handle requeue and errors
 			if !equality.Semantic.DeepEqual(current, target) {
 				//write back to cluster
-				w.client.NetworkingV1().Ingresses(target.Namespace).Update(ctx, target, metav1.UpdateOptions{})
+				_, _ = w.client.NetworkingV1().Ingresses(target.Namespace).Update(ctx, target, metav1.UpdateOptions{})
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
@@ -120,11 +120,11 @@ func (w *ClusterWatcher) Start(ctx context.Context) error {
 			current := obj.(*networkingv1.Ingress)
 			target := current.DeepCopy()
 			targetAccessor := traffic.NewIngress(target)
-			w.Handler.Handle(ctx, targetAccessor)
+			_, _ = w.Handler.Handle(ctx, targetAccessor)
 			//todo handle requeue and errors
 			if !equality.Semantic.DeepEqual(current, target) {
 				//write back to cluster
-				w.client.NetworkingV1().Ingresses(target.Namespace).Update(ctx, target, metav1.UpdateOptions{})
+				_, _ = w.client.NetworkingV1().Ingresses(target.Namespace).Update(ctx, target, metav1.UpdateOptions{})
 			}
 		},
 	})
@@ -146,7 +146,7 @@ func NewClusterWatcher(mgr manager.Manager, config *rest.Config, handlerFactory 
 		return nil, err
 	}
 
-	handler, err := handlerFactory(config, mgr.GetClient())
+	handler, _ := handlerFactory(config, mgr.GetClient())
 	watcher := &ClusterWatcher{client: watcherClient, ClusterName: config.Host, Handler: handler}
 	err = mgr.Add(watcher)
 	if err != nil {

--- a/pkg/traffic/ingress.go
+++ b/pkg/traffic/ingress.go
@@ -18,7 +18,6 @@ func NewIngress(i *networkingv1.Ingress) *Ingress {
 
 type Ingress struct {
 	*networkingv1.Ingress
-	generatedHost string
 }
 
 func (a *Ingress) GetKind() string {


### PR DESCRIPTION
Add the golangci-lint check to the Makefile, config for it, a github action to run it on PRs back to main, and fixes for current issues.

Adds a fix for the Dockerfile and removes external dns from the local setup.


GH Workflow tested here https://github.com/mikenairn/multi-cluster-traffic-controller/actions/runs/4014580657/jobs/6895274887