### PR TITLE
provide a sample applicationset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,10 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
+.PHONY: deploy-sample-applicationset
+deploy-sample-applicationset:
+	kubectl apply -f ./samples/argocd-applicationset/echo-applicationset.yaml
+
 ##@ Build Dependencies
 
 ## Location to install dependencies to

--- a/samples/argocd-applicationset/echo-applicationset.yaml
+++ b/samples/argocd-applicationset/echo-applicationset.yaml
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: echo-app
+  namespace: argocd
+spec:
+  generators:
+    - list:
+        elements:
+          - cluster: mctc-control-plane
+            url: https://kubernetes.default.svc
+  template:
+    metadata:
+      name: '{{cluster}}-echo-app'
+    spec:
+      project: default
+      source:
+        repoURL: 'https://github.com/Kuadrant/multi-cluster-traffic-controller.git'
+        targetRevision: HEAD
+        path: samples/echo-service
+      destination:
+        server: '{{url}}'
+        namespace: echo-app
+      syncPolicy:
+        automated:
+          prune: true
+        syncOptions:
+          - CreateNamespace=true


### PR DESCRIPTION
## What 
Adding make target to deploy a sample applicationset. It would target the `mctc-control-plane` and will deploy an echo application from `samples/echo-service/echo.yaml`. 

## Verification 
1. `make local-setup`
2. `make deploy-sample-applicationset`
3. See the application created in the ArgoCD UI
