### PR TITLE
local-setup/multiple-workload-clusters

### DIFF
--- a/hack/.argocdUtils
+++ b/hack/.argocdUtils
@@ -1,0 +1,38 @@
+# shellcheck shell=bash
+
+argocdAddCluster() {
+    local hubCluster=$1
+    local managedCluster=$2
+
+    local tmpfile=$(mktemp /tmp/kubeconfig-internal.XXXXXX)
+    ${KIND_BIN} export kubeconfig --internal --name ${managedCluster} --kubeconfig ${tmpfile}
+    local server=$(kubectl --kubeconfig ${tmpfile} config view -o jsonpath="{$.clusters[?(@.name == 'kind-${managedCluster}')].cluster.server}")
+    local caData=$(kubectl --kubeconfig ${tmpfile} config view --raw -o jsonpath="{$.clusters[?(@.name == 'kind-${managedCluster}')].cluster.certificate-authority-data}")
+    local certData=$(kubectl --kubeconfig ${tmpfile} config view --raw -o jsonpath="{$.users[?(@.name == 'kind-${managedCluster}')].user.client-certificate-data}")
+    local keyData=$(kubectl --kubeconfig ${tmpfile} config view --raw -o jsonpath="{$.users[?(@.name == 'kind-${managedCluster}')].user.client-key-data}")
+    rm -f ${tmpfile}
+
+    cat <<EOF | kubectl apply --context kind-${hubCluster} -f -
+kind: Secret
+apiVersion: v1
+metadata:
+  name: ${managedCluster}
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+stringData:
+  config: >-
+    {
+      "tlsClientConfig":
+        {
+          "insecure": false,
+          "caData": "${caData}",
+          "certData": "${certData}",
+          "keyData": "${keyData}"
+        }
+    }
+  name: ${managedCluster}
+  server: ${server}
+type: Opaque
+EOF
+}

--- a/hack/.kindUtils
+++ b/hack/.kindUtils
@@ -1,9 +1,9 @@
 # shellcheck shell=bash
 
 kindCreateCluster() {
-  cluster=$1;
-  port80=$2;
-  port443=$3;
+  local cluster=$1;
+  local port80=$2;
+  local port443=$3;
   cat <<EOF | ${KIND_BIN} create cluster --name ${cluster} --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4


### PR DESCRIPTION
Adds the local-setup script the capability of creating workload clusters and registering them with argocd in the control-plane cluster. The number of workload clusters can be set with the environment variable `MCTC_WORKLOAD_CLUSTERS_COUNT`. If the variable is unset or empty only the control plane cluster will be created.
