### PR TITLE
HCG-171 add make targets for prow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
-include ./hack/make/agent.make ./hack/make/controller.make ./hack/make/syncer.make ./hack/make/dependencies.make
+include ./hack/make/*.make
 
 .PHONY: all
 all: build

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,20 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- david-martin
+- mikenairn
+- philbrookes
+- sergioifg94
+- maleck13
+
+reviewers:
+- david-martin
+- mikenairn
+- philbrookes
+- sergioifg94
+- R-Lawton
+- roivaz
+- pmccarthy
+- maleck13
+- makslion
+- jasonmadigan

--- a/hack/make/check.make
+++ b/hack/make/check.make
@@ -1,0 +1,5 @@
+##@ Check
+## Targets to be used to ensure code quality
+.PHONY: verify-code
+verify-code: vet lint ## Verify code formatting
+	@diff -u <(echo -n) <(gofmt -d `find . -type f -name '*.go' -not -path "./vendor/*"`)


### PR DESCRIPTION
## What 
Adding:
* `make code/fix` - to format and fix the code 
* `make code/check` to enable prow ensuring the code in PR is formatted 
* `make vendor/fix` to clean/fix up vendors 
* `make vendor/check` to enable prow ensuring vendors are fine 

## Verification 
1. Ensure commands are working as expected 
2. Ensure vendor changes in this PR aren't causing any trouble. 