### PR TITLE
Update kindest node image to 1.26

### DIFF
--- a/hack/.kindUtils
+++ b/hack/.kindUtils
@@ -9,7 +9,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.24.7@sha256:5c015142d9b60a0f6c45573f809957076514e38ec973565e2b2fe828b91597f5
+  image: kindest/node:v1.26.0
   kubeadmConfigPatches:
   - |
     kind: InitConfiguration


### PR DESCRIPTION
2 reasons:
- keep up to date
- fix issue below seen on some local dev environments

```
 ✓ Ensuring node image (kindest/node:v1.24.7) 🖼
 ✗ Preparing nodes 📦
ERROR: failed to create cluster: could not find a log line that matches "Reached target .*Multi-User System.*|detected cgroup v1"
make: *** [local-setup] Error 1
```