### PR TITLE
WIP Add RUN_IN_CLUSTER_SETUP option to local-setup

### DIFF
--- a/hack/.argocdUtils
+++ b/hack/.argocdUtils
@@ -3,9 +3,10 @@
 argocdAddCluster() {
     local hubCluster=$1
     local managedCluster=$2
+    local internal=$3
 
     local tmpfile=$(mktemp /tmp/kubeconfig-internal.XXXXXX)
-    ${KIND_BIN} export kubeconfig --internal --name ${managedCluster} --kubeconfig ${tmpfile}
+    ${KIND_BIN} export kubeconfig --internal=${internal} --name=${managedCluster} --kubeconfig=${tmpfile}
     local server=$(kubectl --kubeconfig ${tmpfile} config view -o jsonpath="{$.clusters[?(@.name == 'kind-${managedCluster}')].cluster.server}")
     local caData=$(kubectl --kubeconfig ${tmpfile} config view --raw -o jsonpath="{$.clusters[?(@.name == 'kind-${managedCluster}')].cluster.certificate-authority-data}")
     local certData=$(kubectl --kubeconfig ${tmpfile} config view --raw -o jsonpath="{$.users[?(@.name == 'kind-${managedCluster}')].user.client-certificate-data}")


### PR DESCRIPTION
local-setup is intended for local development, and mostly you would be running the controller locally. Currently this is not possible because it's assuming the controller will be running in a kind cluster with internal access (--internal option used when extracting the kubeconfig).

The RUN_IN_CLUSTER_SETUP option allows you do either, but defaults to false to allow local development to work as normal.

To run local-setup when you intend to run the controller on the cluster, use:
```
RUN_IN_CLUSTER_SETUP=true make local-setup
```

Also removes externalDNS from local setup again.

Doesn't completely resolve local-setup issues, but along with changes in this PR https://github.com/Kuadrant/multi-cluster-traffic-controller/pull/31, hopefully it will.