### PR TITLE
Kuadrant operator

### DIFF
--- a/config/kuadrant/kustomization.yaml
+++ b/config/kuadrant/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- github.com/Kuadrant/kuadrant-operator/config/deploy?ref=main

--- a/hack/local-setup.sh
+++ b/hack/local-setup.sh
@@ -206,7 +206,7 @@ if [[ -n "${MCTC_WORKLOAD_CLUSTERS_COUNT}" ]]; then
     installGatewayAPI ${KIND_CLUSTER_WORKLOAD}-${i}
     deployIngressController ${KIND_CLUSTER_WORKLOAD}-${i}
     deployIstio ${KIND_CLUSTER_WORKLOAD}-${i}
-    deployKuadrant ${KIND_CLUSTER_CONTROL_PLANE}-${i}
+    deployKuadrant ${KIND_CLUSTER_WORKLOAD}-${i}
     deployWebhookConfigs ${KIND_CLUSTER_WORKLOAD}-${i}
     deployDashboard ${KIND_CLUSTER_WORKLOAD}-${i} ${i}
     argocdAddCluster ${KIND_CLUSTER_CONTROL_PLANE} ${KIND_CLUSTER_WORKLOAD}-${i}


### PR DESCRIPTION
# Verification
1. Run make local setup 
`make local-setup MCTC_WORKLOAD_CLUSTERS_COUNT=<NUMBER_OF_CLUSTERS>`


Check  in the workload cluster that the following happens:
Note make sure you switch context to the right workload clusters
` kubectl config use-context kind-mctc-workload-1`
1. Namespace called `kuadrant-system` gets created
3. Operator gets installed
4. Kuadrant API CRDs should be available
`kubectl get crds | grep kuadrant`
```
authconfigs.authorino.kuadrant.io           2023-02-14T13:19:51Z
authorinos.operator.authorino.kuadrant.io   2023-02-14T13:19:51Z
authpolicies.kuadrant.io                    2023-02-14T13:19:47Z
kuadrants.kuadrant.io                       2023-02-14T13:19:47Z
limitadors.limitador.kuadrant.io            2023-02-14T13:19:51Z
ratelimitpolicies.kuadrant.io               2023-02-14T13:19:47Z
```

