### PR TITLE
Specify local docker network

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,10 @@ test: manifests generate fmt vet envtest ## Run tests.
 local-setup: kind kustomize helm yq dev-tls ## Setup multi cluster traffic controller locally using kind.
 	./hack/local-setup.sh
 
+.PHONY: local-cleanup
+local-cleanup: kind ## Cleanup resources created by local-setup
+	./hack/local-cleanup.sh
+
 ##@ Build
 .PHONY: build-controller
 build-controller: manifests generate fmt vet ## Build controller binary.
@@ -146,7 +150,7 @@ deploy-sample-applicationset:
 
 .PHONY: dev-tls
 dev-tls:
-	test -s config/webhook-setup/control/tls/tls.crt || openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout config/webhook-setup/control/tls/tls.key -out config/webhook-setup/control/tls/tls.crt -subj "/C=IE/O=Red Hat Ltd/OU=HCG/CN=webhook.172.18.0.2.nip.io" -addext "subjectAltName = DNS:webhook.172.18.0.2.nip.io"
+	test -s config/webhook-setup/control/tls/tls.crt || openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout config/webhook-setup/control/tls/tls.key -out config/webhook-setup/control/tls/tls.crt -subj "/C=IE/O=Red Hat Ltd/OU=HCG/CN=webhook.172.32.0.2.nip.io" -addext "subjectAltName = DNS:webhook.172.32.0.2.nip.io"
 
 .PHONY: clear-dev-tls
 clear-dev-tls:

--- a/config/argocd/ingress-argocd-server.yaml
+++ b/config/argocd/ingress-argocd-server.yaml
@@ -19,7 +19,7 @@ spec:
                 name: mctc-argocd-server
                 port:
                   number: 80
-    - host: argocd.172.18.0.2.nip.io
+    - host: argocd.172.32.0.2.nip.io
       http:
         paths:
           - path: /

--- a/config/webhook-setup/control/ingress.yaml
+++ b/config/webhook-setup/control/ingress.yaml
@@ -7,10 +7,10 @@ metadata:
 spec:
   tls:
   - hosts:
-    - webhook.172.18.0.2.nip.io
+    - webhook.172.32.0.2.nip.io
     secretName: mctc-ingress-tls
   rules:
-    - host: webhook.172.18.0.2.nip.io
+    - host: webhook.172.32.0.2.nip.io
       http:
         paths:
           - path: /

--- a/config/webhook-setup/workload/webhook-configs.yaml
+++ b/config/webhook-setup/workload/webhook-configs.yaml
@@ -6,7 +6,7 @@ webhooks:
   - name: "mctc.ingress.dev"
     clientConfig:
       caBundle: ""
-      url: https://webhook.172.18.0.2.nip.io/ingress
+      url: https://webhook.172.32.0.2.nip.io/ingress
     timeoutSeconds: 5
     sideEffects: NoneOnDryRun
     admissionReviewVersions: ["v1"]

--- a/hack/.cleanupUtils
+++ b/hack/.cleanupUtils
@@ -1,0 +1,21 @@
+# shellcheck shell=bash
+
+cleanClusters() {
+	# Delete existing kind clusters
+	clusterCount=$(${KIND_BIN} get clusters | grep ${KIND_CLUSTER_PREFIX} | wc -l)
+	if ! [[ $clusterCount =~ "0" ]] ; then
+		echo "Deleting previous kind clusters."
+		${KIND_BIN} get clusters | grep ${KIND_CLUSTER_PREFIX} | xargs ${KIND_BIN} delete clusters
+	fi	
+}
+
+cleanNetwork() {
+    # Delete the network
+    echo "Deleting mctc network"
+    docker network rm mctc || true
+}
+
+cleanup() {
+	cleanClusters
+	cleanNetwork
+}

--- a/hack/.cleanupUtils
+++ b/hack/.cleanupUtils
@@ -10,12 +10,23 @@ cleanClusters() {
 }
 
 cleanNetwork() {
-    # Delete the network
-    echo "Deleting mctc network"
-    docker network rm mctc || true
+  # Delete the network
+  echo "Deleting mctc network"
+  docker network rm mctc || true
+}
+
+stopProxies() {
+  if [[ -f /tmp/dashboard_pids ]]; then
+    echo "Stopping existing proxies"
+    while read p; do
+      kill $p
+    done </tmp/dashboard_pids
+    rm /tmp/dashboard_pids
+  fi
 }
 
 cleanup() {
-	cleanClusters
-	cleanNetwork
+  stopProxies
+  cleanClusters
+  cleanNetwork
 }

--- a/hack/.kindUtils
+++ b/hack/.kindUtils
@@ -4,6 +4,7 @@ kindCreateCluster() {
   local cluster=$1;
   local port80=$2;
   local port443=$3;
+  export KIND_EXPERIMENTAL_DOCKER_NETWORK=mctc
   cat <<EOF | ${KIND_BIN} create cluster --name ${cluster} --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4

--- a/hack/local-cleanup.sh
+++ b/hack/local-cleanup.sh
@@ -1,0 +1,7 @@
+LOCAL_SETUP_DIR="$(dirname "${BASH_SOURCE[0]}")"
+source "${LOCAL_SETUP_DIR}"/.setupEnv
+source "${LOCAL_SETUP_DIR}"/.cleanupUtils
+
+KIND_CLUSTER_PREFIX="mctc-"
+
+cleanup


### PR DESCRIPTION
## Description

Currently, some of the configuration resources assume the IP of the control cluster being `172.17.0.2`. This is correct in the case of the local machine having no previous docker networks, as the creation of the kind clusters results in the creation of a bridge network and the IP range automatically assigned. However, in the scenario where there are other previous networks in the machine, the IP of the cluster will not match the IP specified in the resources.

As a first step to ensure consistency regardless of the current networks, modify the `local-setup` script to pre-create a network in the `172.32.0.0` subnet, and configure kind to use that network instead of automatically creating one. Update the resources that reference the control cluster IP to the new subnet

## Verification steps

In order to verify this, run the `local-setup` script and verify that the clusters are functioning correctly

Verify as well that the `mctc` docker network has been created
```sh
docker network inspect mctc
```

> A new `make` directive `local-cleanup` has been added to clean up resources that are created when running `local-setup`

Verify the `local-cleanup` by running `make local-cleanup` and ensuring the kind clusters and the network are deleted 
