### PR TITLE
deploy agent from kustomize yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,22 @@ When deploying the multi cluster traffic controller using the make targets the f
     ```sh
     (export $(cat ./controller-config.env | xargs) && export $(cat ./aws-credentials.env | xargs) && make build install run
     ```
-## 3. Run the ingress agent locally
+
+## 3. Deploy the agent
+1. Update the secret in `config/agent/secret.yaml` with the correct credentials for the control plane. (**N.B.** The server should remain `https://mctc-control-plane-control-plane:6443`)
+
+1. Build the agent image and load it into the workload cluster
+    ```sh
+    export KUBECONFIG=./hack/kubeconfigs/mctc-workload-1.kubeconfig
+    make kind-load-agent
+    ```
+
+1. Deploy the agent to the workload cluster
+    ```sh
+    make deploy-agent
+    ```
+    
+## 4. Run the ingress agent locally
 1. Target the workload cluster you wish to run on:
 ```sh
 export KUBECONFIG=./hack/kubeconfigs/mctc-workload-1.kubeconfig

--- a/config/agent/agent.yaml
+++ b/config/agent/agent.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mctc-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sync-agent
+  namespace: mctc-system
+spec:
+  selector:
+    matchLabels:
+      control-plane: sync-agent
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: sync-agent
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      containers:
+      - command:
+        - /agent
+        args:
+        - --leader-elect
+        - -control-plane-config-namespace=mctc-system
+        image: agent:latest
+        imagePullPolicy: Never
+        name: agent
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - "ALL"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        # TODO(user): Configure the resources accordingly based on the project requirements.
+        # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+      serviceAccountName: sync-agent
+      terminationGracePeriodSeconds: 10

--- a/config/agent/kustomization.yaml
+++ b/config/agent/kustomization.yaml
@@ -1,0 +1,14 @@
+# Adds namespace to all resources.
+namespace: mctc-system
+resources:
+- role.yaml
+- serviceaccount.yaml
+- rolebinding.yaml
+- secret.yaml
+- agent.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: agent
+  newName: agent
+  newTag: latest

--- a/config/agent/role.yaml
+++ b/config/agent/role.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: agent-role
+rules:
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - update
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/config/agent/rolebinding.yaml
+++ b/config/agent/rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: agent-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: agent-role
+subjects:
+- kind: ServiceAccount
+  name: sync-agent
+  namespace: mctc-system

--- a/config/agent/secret.yaml
+++ b/config/agent/secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+  name: control-plane-cluster
+  namespace: mctc-system
+stringData:
+  name: kind-mctc-workload-1
+  server: https://mctc-control-plane-control-plane:6443
+  config: |
+    {
+      "tlsClientConfig": {
+        "insecure": true,
+        "caData": "",
+        "certData": "",
+        "keyData": ""
+      }
+    } 

--- a/config/agent/serviceaccount.yaml
+++ b/config/agent/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sync-agent
+  namespace: mctc-system


### PR DESCRIPTION
- Follow the steps in the readme to deploy the controller.
- Follow the steps in the readme to deploy the agent.
- Create sample application in workload cluster: `kubectl create -f samples/syncer/application.yaml`
- Watch logs of agent for: certificate secret in place for  host adding dns endpoints
- Curl the host.