### PR TITLE
Patch istiod config for local environment use

### DIFF
--- a/config/istio/istiod/configmap.yaml
+++ b/config/istio/istiod/configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+data:
+  mesh: |-
+    defaultConfig:
+      discoveryAddress: istiod.istio-system.svc:15012
+      tracing:
+        zipkin:
+          address: zipkin.istio-system:9411
+    enablePrometheusMerge: true
+    rootNamespace: istio-system
+    trustDomain: cluster.local
+  meshNetworks: 'networks: {}'
+kind: ConfigMap
+metadata:
+  name: istio

--- a/config/istio/istiod/kustomization.yaml
+++ b/config/istio/istiod/kustomization.yaml
@@ -10,3 +10,10 @@ helmCharts:
     releaseName: mctc
     namespace: istio
     includeCRDs: true
+
+# Ensure default config is correct for local environment
+patches:
+- path: configmap.yaml
+  target:
+    kind: ConfigMap
+    name: istio

--- a/config/samples/gateway_istio.yaml
+++ b/config/samples/gateway_istio.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: istio
+  labels:
+    istio: ingressgateway
+spec:
+  gatewayClassName: istio
+  listeners:
+  - name: default
+    port: 80
+    protocol: HTTP
+    hostname: "test.example.com"
+    allowedRoutes:
+      namespaces:
+        from: All


### PR DESCRIPTION
This fixes an istiod configuration issue that results in an istio gateway not being usable.

## Reproducing the issue

To reproduce the issue on `main`, start a local dev environment with 1 workload cluster:
```
MCTC_WORKLOAD_CLUSTERS_COUNT=1 make local-setup
```
Then create an istio Gateway resource in the workload cluster
```
kubectl --context kind-mctc-workload-1 apply -n istio-system -f https://raw.githubusercontent.com/david-martin/multi-cluster-traffic-controller/istiod_config/config/samples/gateway_istio.yaml
```
Check the logs for the below lines that indicate the configuration issue
```
kubectl --context kind-mctc-workload-1 -n istio-system logs -f $(kubectl --context kind-mctc-workload-1 -n istio-system get po -l istio=ingressgateway -o name) | grep -i xds

2023-02-17T10:53:47.731173Z	info	xdsproxy	Initializing with upstream address "istiod.istio.svc:15012" and cluster "Kubernetes"
2023-02-17T10:54:43.347990Z	warning	envoy config	StreamAggregatedResources gRPC config stream to xds-grpc closed since 55s ago: 14, connection error: desc = "transport: Error while dialing dial tcp: lookup istiod.istio.svc on 10.96.0.10:53: no such host"
```

## Verifying the fix

Follow the same instructions as above on this branch.
This time the following logs should be seen:
```
2023-02-17T10:55:47.108859Z	info	xdsproxy	Initializing with upstream address "istiod.istio-system.svc:15012" and cluster "Kubernetes"
2023-02-17T10:55:47.155771Z	info	xdsproxy	connected to upstream XDS server: istiod.istio-system.svc:15012
```