### PR TITLE
Fix the controller image build in GH actions

### DIFF
--- a/.github/workflows/mctc-image.yaml
+++ b/.github/workflows/mctc-image.yaml
@@ -4,12 +4,11 @@ on:
   push:
     branches:
       - main
-      - 'release-*'
+      - "release-*"
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 env:
-  IMG_TAGS: ${{ github.ref_name }}
   IMG_REGISTRY_HOST: quay.io
   IMG_REGISTRY_ORG: kuadrant
   IMG_REGISTRY_REPO: multi-cluster-traffic-controller
@@ -22,47 +21,42 @@ jobs:
     runs-on: ubuntu-20.04
     outputs:
       sha_short: ${{ steps.vars.outputs.sha_short }}
-      controller_image: ${{ steps.vars-image.outputs.controller_image }}
+      controller_image: ${{ steps.vars.outputs.base_image }}:${{ steps.vars.outputs.sha_short }}
     steps:
       - uses: actions/checkout@v2
 
-      - name: Get the short sha
+      - name: Calculate vars
         id: vars
-        run: echo "sha_short=$(echo ${{ github.sha }} | cut -b -7)" >> $GITHUB_OUTPUT
-
-      - name: Get the controller image
-        id: vars-image
-        run: echo "controller_image=${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.IMG_REGISTRY_REPO }}:${{ steps.vars.outputs.sha_short }}" >> $GITHUB_OUTPUT
-
-      - name: Add short sha tag
-        id: add-sha-tag
         run: |
-          echo "IMG_TAGS=${{ steps.vars.outputs.sha_short }} ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
+          echo "sha_short=$(echo ${{ github.sha }} | cut -b -7)" >> $GITHUB_OUTPUT
+          echo "base_image=${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.IMG_REGISTRY_REPO }}" >> $GITHUB_OUTPUT
+
+      - name: Add image tags
+        id: add-tags
+        run: echo "IMG_TAGS=${{ steps.vars.outputs.base_image }}:${{ steps.vars.outputs.sha_short }},${{ steps.vars.outputs.base_image }}:${{ github.ref_name }}" >> $GITHUB_ENV
 
       - name: Add latest tag
         if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
         id: add-latest-tag
-        run: |
-          echo "IMG_TAGS=latest ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
+        run: echo "IMG_TAGS=${{ steps.vars.outputs.base_image }}:latest,${{ env.IMG_TAGS }}" >> $GITHUB_ENV
 
-      - name: Build MCTC Image
-        id: build-image
-        uses: redhat-actions/buildah-build@v2
+      - name: Login to Quay.io
+        uses: docker/login-action@v2
+        id: registry-login
         with:
-          image: ${{ env.IMG_REGISTRY_REPO }}
-          tags: ${{ env.IMG_TAGS }}
-          containerfiles: |
-            ./Dockerfile
-
-      - name: Push to quay.io
-        id: push-to-quay
-        uses: redhat-actions/push-to-registry@v2
-        with:
-          image: ${{ steps.build-image.outputs.image }}
-          tags: ${{ steps.build-image.outputs.tags }}
-          registry: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}
+          registry: ${{ env.IMG_REGISTRY_HOST }}
           username: ${{ secrets.IMG_REGISTRY_USERNAME }}
           password: ${{ secrets.IMG_REGISTRY_TOKEN }}
 
+      - name: Build and push MCTC Image
+        id: build-and-push
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: ${{ env.IMG_TAGS }}
+          target: controller
+
       - name: Print Image URL
-        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+        run: |
+          echo "Image pushed to ${{ env.IMG_TAGS }}"
+          echo "Image digest: ${{ steps.build-and-push.outputs.digest }}"


### PR DESCRIPTION
The Dockerfile now contains build targets for both the controller and the agent, so we need to specify which target we want to build in the build action (right now it's building just the last one, which happens to be the agent). 'redhat-actions/buildah-build@v2' doesn't have support for the 'target' paremeter, so I have switched to the
'docker/build-push-action@v4' action instead. It required quite a few changes as the format of the parameters is different.

I could easily add builds for the agent to this same workflo, but it might be better to have a different workflow to have separate success/failure notifications for both images, wdyt?

Check the test run [here](https://github.com/Kuadrant/multi-cluster-traffic-controller/actions/runs/4203440226/jobs/7292834721)