### PR TITLE
GH-32: Add proxy to enable webhooks when running locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,10 @@ clear-dev-tls:
 	-rm -f $(DEV_TLS_CRT)
 	-rm -f $(DEV_TLS_KEY)
 
+.PHONY: webhook-proxy
+webhook-proxy: kustomize
+	$(KUSTOMIZE) --load-restrictor LoadRestrictionsNone build config/webhook-setup/proxy | kubectl apply -f -
+
 ##@ Build Dependencies
 
 ## Location to install dependencies to

--- a/config/webhook-setup/proxy/deployment.yaml
+++ b/config/webhook-setup/proxy/deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: webhook-proxy
+  namespace: system
+spec:
+  selector:
+    matchLabels:
+      control-plane: webhook-proxy
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: nginx
+      labels:
+        control-plane: webhook-proxy
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 8082
+          name: webhooks
+          protocol: TCP
+        volumeMounts:
+        - name: nginx-config-volume
+          mountPath: /etc/nginx
+      volumes:
+      - name: nginx-config-volume
+        configMap:
+          name: mctc-webhook-proxy-conf
+      

--- a/config/webhook-setup/proxy/kustomization.yaml
+++ b/config/webhook-setup/proxy/kustomization.yaml
@@ -1,0 +1,23 @@
+namespace: multi-cluster-traffic-controller-system
+
+namePrefix: mctc-
+
+resources:
+- namespace.yaml
+- deployment.yaml
+- service.yaml
+- ../control/ingress.yaml
+
+configMapGenerator:
+  - name: webhook-proxy-conf
+    files:
+      - nginx.conf
+
+secretGenerator:
+- name: ingress-tls
+  files:
+    - ../control/tls/tls.crt
+    - ../control/tls/tls.key
+
+generatorOptions:
+  disableNameSuffixHash: true

--- a/config/webhook-setup/proxy/namespace.yaml
+++ b/config/webhook-setup/proxy/namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: webhook-proxy
+    app.kubernetes.io/name: namespace
+    app.kubernetes.io/created-by: multi-cluster-traffic-controller
+    app.kubernetes.io/part-of: multi-cluster-traffic-controller
+    app.kubernetes.io/managed-by: kustomize
+  name: system

--- a/config/webhook-setup/proxy/nginx.conf
+++ b/config/webhook-setup/proxy/nginx.conf
@@ -1,0 +1,19 @@
+events {
+  worker_connections  1024;
+}
+
+http {
+
+	server {
+
+		listen 8082;
+
+		location / {
+
+			proxy_pass http://172.32.0.1:8082$uri$is_args$args;
+
+		}
+
+	}
+
+}

--- a/config/webhook-setup/proxy/service.yaml
+++ b/config/webhook-setup/proxy/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhooks
+spec:
+  ports:
+    - name: webhooks
+      port: 8082
+      targetPort: webhooks
+      protocol: TCP
+  selector:
+    control-plane: webhook-proxy

--- a/hack/local-setup.sh
+++ b/hack/local-setup.sh
@@ -193,6 +193,15 @@ deployWebhookConfigs(){
   kubectl apply -f $WEBHOOK_PATH/webhook-configs.yaml
 }
 
+deployWebhookProxy(){
+  clusterName=${1}
+  echo "Deploying the webhook proxy to (${clusterName})"
+
+  kubectl config use-context kind-${clusterName}
+
+  ${KUSTOMIZE_BIN} --load-restrictor LoadRestrictionsNone build config/webhook-setup/proxy | kubectl apply -f -
+}
+
 cleanup
 
 port80=9090
@@ -225,6 +234,8 @@ deployDashboard $KIND_CLUSTER_CONTROL_PLANE 0
 
 #7. Add the control plane cluster
 argocdAddCluster ${KIND_CLUSTER_CONTROL_PLANE} ${KIND_CLUSTER_CONTROL_PLANE}
+
+deployWebhookProxy ${KIND_CLUSTER_CONTROL_PLANE}
 
 #8. Add workload clusters if MCTC_WORKLOAD_CLUSTERS_COUNT environment variable is set
 if [[ -n "${MCTC_WORKLOAD_CLUSTERS_COUNT}" ]]; then


### PR DESCRIPTION
## Description

> Closes #32 

Add a command to deploy a simple proxy in the control cluster, which redirects requests to the local host, and is exposed as the webhook endpoint. This allows the workload clusters to maintain the same webhook configuration while running the controller in the localhost

## Verification

Follow the instructions in the [README](https://github.com/Kuadrant/multi-cluster-traffic-controller/blob/4b9e56c32526ee5ca127a9b8711aaca774214d98/README.md#2-running-locally) to run the controller locally and ensure the webhooks are reachable