### PR TITLE
dumb sync - spec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ COPY pkg/ pkg/
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o controller cmd/controller/main.go
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o agent cmd/agent/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o syncer cmd/syncer/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
@@ -40,3 +41,12 @@ COPY --from=builder /workspace/agent .
 USER 65532:65532
 
 ENTRYPOINT ["/agent"]
+
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot as syncer
+WORKDIR /
+COPY --from=builder /workspace/syncer .
+USER 65532:65532
+
+ENTRYPOINT ["/syncer"]

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 
 # Image URL to use all building/pushing image targets
 TAG ?= latest
-CONTROLLER_IMG ?= controller:$(TAG)
-AGENT_IMG ?= agent:$(TAG)
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.25.0
@@ -18,6 +16,8 @@ endif
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
+
+include ./hack/make/agent.make ./hack/make/controller.make ./hack/make/syncer.make ./hack/make/dependencies.make
 
 .PHONY: all
 all: build
@@ -79,54 +79,10 @@ local-cleanup: kind ## Cleanup resources created by local-setup
 	./hack/local-cleanup.sh
 	$(MAKE) clean
 
-##@ Build
-
 .PHONY: build
-build: build-controller build-agent ## Build all binaries.
-
-.PHONY: build-controller
-build-controller: manifests generate fmt vet ## Build controller binary.
-	go build -o bin/controller ./cmd/controller/main.go
-
-.PHONY: run-controller
-run-controller: manifests generate fmt vet install ## Run controller from your host.
-	go run ./cmd/controller/main.go
-
-build-agent: manifests generate fmt vet ## Build agent binary.
-	go build -o bin/agent ./cmd/agent/main.go
-
-.PHONY: run-agent
-run-agent: manifests generate fmt vet install ## Run agent from your host.
-	go run ./cmd/agent/main.go --control-plane-config-namespace=mctc-system
-
-.PHONY: docker-build-controller
-docker-build-controller: test ## Build docker image with the controller.
-	docker build --target controller -t ${CONTROLLER_IMG} .
-
-.PHONY: kind-load-controller
-kind-load-controller: docker-build-controller
-	kind load docker-image ${CONTROLLER_IMG} --name mctc-control-plane  --nodes mctc-control-plane-control-plane
-
-.PHONY: docker-push-controller
-docker-push-controller: ## Push docker image with the controller.
-	docker push ${CONTROLLER_IMG}
-
-.PHONY: docker-build-agent
-docker-build-agent: test ## Build docker image with the agent.
-	docker build --target agent -t ${AGENT_IMG} .
-	docker image prune -f --filter label=stage=mctc-builder
-
-.PHONY: docker-push-agent
-docker-push-agent: ## Push docker image with the controller.
-	docker push ${AGENT_IMG}
-
-.PHONY: kind-load-agent
-kind-load-agent: docker-build-agent
-	kind load docker-image ${AGENT_IMG} --name mctc-workload-1  --nodes mctc-workload-1-control-plane
-
+build: build-controller build-agent build-syncer## Build all binaries.
 
 ##@ Deployment
-
 ifndef ignore-not-found
   ignore-not-found = false
 endif
@@ -138,30 +94,6 @@ install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
-
-.PHONY: deploy-controller
-deploy-controller: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${CONTROLLER_IMG}
-	$(KUSTOMIZE) --load-restrictor LoadRestrictionsNone build config/deploy/local | kubectl apply -f -
-
-.PHONY: agent-secret
-agent-secret: kustomize kind yq
-	./hack/gen-agent-secret.sh
-	
-.PHONY: deploy-agent
-deploy-agent: manifests kustomize kind yq agent-secret ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/agent && $(KUSTOMIZE) edit set image agent=${AGENT_IMG}
-	$(KUSTOMIZE) build config/agent | kubectl apply -f -
-
-.PHONY: undeploy-controller
-undeploy-controller: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
-
-
-.PHONY: undeploy-agent
-undeploy-agent: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/agent | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
-
 
 .PHONY: deploy-sample-applicationset
 deploy-sample-applicationset:
@@ -184,61 +116,3 @@ clear-dev-tls:
 .PHONY: webhook-proxy
 webhook-proxy: kustomize
 	$(KUSTOMIZE) --load-restrictor LoadRestrictionsNone build config/webhook-setup/proxy | kubectl apply -f -
-
-##@ Build Dependencies
-
-## Location to install dependencies to
-LOCALBIN ?= $(shell pwd)/bin
-$(LOCALBIN):
-	mkdir -p $(LOCALBIN)
-
-## Tool Binaries
-KUSTOMIZE ?= $(LOCALBIN)/kustomize
-CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
-ENVTEST ?= $(LOCALBIN)/setup-envtest
-KIND ?= $(LOCALBIN)/kind
-HELM ?= $(LOCALBIN)/helm
-
-## Tool Versions
-KUSTOMIZE_VERSION ?= v4.5.4
-CONTROLLER_TOOLS_VERSION ?= v0.10.0
-KIND_VERSION ?= v0.14.0
-HELM_VERSION ?= v3.10.0
-YQ_VERSION ?= v4.30.8
-
-KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
-.PHONY: kustomize
-kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.
-$(KUSTOMIZE): $(LOCALBIN)
-	@if test -x $(LOCALBIN)/kustomize && ! $(LOCALBIN)/kustomize version | grep -q $(KUSTOMIZE_VERSION); then \
-		echo "$(LOCALBIN)/kustomize version is not expected $(KUSTOMIZE_VERSION). Removing it before installing."; \
-		rm -rf $(LOCALBIN)/kustomize; \
-	fi
-	test -s $(LOCALBIN)/kustomize || { curl -Ss $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); }
-
-.PHONY: controller-gen
-controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary. If wrong version is installed, it will be overwritten.
-$(CONTROLLER_GEN): $(LOCALBIN)
-	test -s $(LOCALBIN)/controller-gen && $(LOCALBIN)/controller-gen --version | grep -q $(CONTROLLER_TOOLS_VERSION) || \
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
-
-.PHONY: envtest
-envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
-$(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
-
-.PHONY: kind
-kind: $(KIND) ## Download kind locally if necessary.
-$(KIND):
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/kind@$(KIND_VERSION)
-
-HELM_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3"
-.PHONY: helm
-helm: $(HELM)
-$(HELM):
-	curl -s $(HELM_INSTALL_SCRIPT) | HELM_INSTALL_DIR=$(LOCALBIN) PATH=$$PATH:$$HELM_INSTALL_DIR bash -s -- --no-sudo --version $(HELM_VERSION)
-
-.PHONY: yq
-yq: $(YQ)
-	test -s $(LOCALBIN)/yq || GOBIN=$(LOCALBIN) go install github.com/mikefarah/yq/v4@$(YQ_VERSION)
-

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -58,9 +58,9 @@ func main() {
 	var controlPlaneConfigSecretName string
 	var controlPlaneConfigSecretNamespace string
 
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8084", "The address the metric endpoint binds to.")
-	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8085", "The address the probe endpoint binds to.")
-	flag.StringVar(&controlPlaneConfigSecretName, "control-plane-cluster", "control-plane-cluster", "The name of the secret with the control plane client configuration")
+	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&controlPlaneConfigSecretName, "control-plane-config-name", "control-plane-cluster", "The name of the secret with the control plane client configuration")
 	flag.StringVar(&controlPlaneConfigSecretNamespace, "control-plane-config-namespace", "default", "The namespace containing the secret with the control plane client configuration")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -90,7 +90,7 @@ func main() {
 		Port:                   9443,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "fb80029c.kuadrant.io",
+		LeaderElectionID:       "fb80029c-controller.kuadrant.io",
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2022 The MultiCluster Traffic Controller Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	corev1 "k8s.io/api/core/v1"
+	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	// to ensure that exec-entrypoint and run can make use of them.
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	//+kubebuilder:scaffold:imports
+
+	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/_internal/clusterSecret"
+	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/syncer"
+	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/syncer/spec"
+)
+
+var (
+	scheme            = runtime.NewScheme()
+	setupLog          = ctrl.Log.WithName("setup")
+	NEVER_SYNCED_GVRs = []string{"pods"}
+)
+
+const (
+	DEFAULT_RESYNC = 0
+	SYNCER_THREADS = 1
+)
+
+type arrayFlags []string
+
+func (i *arrayFlags) String() string {
+	return strings.Join(*i, ",")
+}
+
+func (i *arrayFlags) Set(value string) error {
+	*i = append(*i, value)
+	return nil
+}
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	//+kubebuilder:scaffold:scheme
+}
+
+func main() {
+	var metricsAddr string
+	var enableLeaderElection bool
+	var probeAddr string
+	var controlPlaneConfigSecretName string
+	var controlPlaneConfigSecretNamespace string
+	var syncedResources arrayFlags
+
+	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&controlPlaneConfigSecretName, "control-plane-config-name", "control-plane-cluster", "The name of the secret with the control plane client configuration")
+	flag.StringVar(&controlPlaneConfigSecretNamespace, "control-plane-config-namespace", "mctc-system", "The namespace containing the secret with the control plane client configuration")
+	flag.Var(&syncedResources, "synced-resources", "A list of GVRs to sync (e.g. ingresses.v1.networking.k8s.io)")
+	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
+		"Enable leader election for controller manager. "+
+			"Enabling this will ensure there is only one active controller manager.")
+	opts := zap.Options{
+		Development: true,
+	}
+
+	opts.BindFlags(flag.CommandLine)
+	flag.Parse()
+
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		Scheme:                 scheme,
+		MetricsBindAddress:     metricsAddr,
+		Port:                   9443,
+		HealthProbeBindAddress: probeAddr,
+		LeaderElection:         enableLeaderElection,
+		LeaderElectionID:       "fb80029c-sync.kuadrant.io",
+	})
+	if err != nil {
+		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
+
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up health check")
+		os.Exit(1)
+	}
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up ready check")
+		os.Exit(1)
+	}
+
+	err = startSyncers(ctrl.SetupSignalHandler(), syncedResources, client.ObjectKey{Namespace: controlPlaneConfigSecretNamespace, Name: controlPlaneConfigSecretName}, mgr)
+	if err != nil {
+		setupLog.Error(err, "unable to start syncers")
+		os.Exit(1)
+	}
+	setupLog.Info("starting manager")
+	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+		setupLog.Error(err, "problem running manager")
+		os.Exit(1)
+	}
+}
+
+func startSyncers(ctx context.Context, GVRs []string, secretRef client.ObjectKey, mgr manager.Manager) error {
+	logger := log.FromContext(ctx)
+	controlPlaneSecret := &corev1.Secret{}
+	secretClient, err := client.New(mgr.GetConfig(), client.Options{})
+	if err != nil {
+		setupLog.Error(err, "unable to create sync secret client")
+		os.Exit(1)
+	}
+	err = secretClient.Get(ctx, secretRef, controlPlaneSecret, &client.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("unable to retrieve control plane config secret '%v', error: %v", secretRef.String(), err)
+
+	}
+
+	upstreamClusterConfig, err := clusterSecret.ClusterConfigFromSecret(controlPlaneSecret)
+	if err != nil {
+		return fmt.Errorf("unable to create cluster config from control plane secret: %v", err)
+	}
+	upstreamRestConfig, err := clusterSecret.RestConfigFromSecret(controlPlaneSecret)
+	if err != nil {
+		return fmt.Errorf("unable to create rest config from control plane secret: %v", err)
+	}
+	upstreamClient, err := clusterSecret.DynamicClientsetFromSecret(controlPlaneSecret)
+	if err != nil {
+		return fmt.Errorf("unable to create client from control plane rest config: %v", err)
+	}
+	informerFactory := dynamicinformer.NewDynamicSharedInformerFactory(upstreamClient, DEFAULT_RESYNC)
+	informerFactory.Start(ctx.Done())
+	informerFactory.WaitForCacheSync(ctx.Done())
+
+	specSyncConfig := syncer.Config{
+		UpstreamClientConfig: upstreamRestConfig,
+		GVRs:                 GVRs,
+		DownStreamClient:     mgr.GetClient(),
+		InformerFactory:      informerFactory,
+		ClusterID:            upstreamClusterConfig.Name,
+		NeverSyncedGVRs:      NEVER_SYNCED_GVRs,
+	}
+
+	downstreamDynamicClient, err := dynamic.NewForConfig(mgr.GetConfig())
+	if err != nil {
+		return fmt.Errorf("could not make dynamic downstream client from manager rest config: %v", err.Error())
+	}
+	SpecSyncer, err := spec.NewSpecSyncer(upstreamClusterConfig.Name, upstreamClusterConfig.Name, upstreamClient, downstreamDynamicClient)
+	if err != nil {
+		return fmt.Errorf("could not create new spec syncer: %v", err.Error())
+	}
+	logger.Info("starting syncer", "name", upstreamClusterConfig.Name)
+
+	go SpecSyncer.Start(ctx, SYNCER_THREADS)
+
+	err = syncer.StartSyncers(ctx, specSyncConfig, syncer.InformerForGVR, SpecSyncer)
+	if err != nil {
+		return fmt.Errorf("error starting syncers, %v", err.Error())
+	}
+
+	return nil
+
+}

--- a/config/syncer/kustomization.yaml
+++ b/config/syncer/kustomization.yaml
@@ -4,10 +4,10 @@ resources:
 - role.yaml
 - serviceaccount.yaml
 - rolebinding.yaml
-- agent.yaml
+- syncer.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- name: agent
-  newName: agent
+- name: syncer
+  newName: syncer
   newTag: latest

--- a/config/syncer/role.yaml
+++ b/config/syncer/role.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: agent-role
+rules:
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - update
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/config/syncer/rolebinding.yaml
+++ b/config/syncer/rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: agent-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: agent-role
+subjects:
+- kind: ServiceAccount
+  name: sync-agent
+  namespace: mctc-system

--- a/config/syncer/serviceaccount.yaml
+++ b/config/syncer/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sync-agent
+  namespace: mctc-system

--- a/config/syncer/syncer.yaml
+++ b/config/syncer/syncer.yaml
@@ -1,8 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: mctc-system
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -15,8 +10,6 @@ spec:
   replicas: 1
   template:
     metadata:
-      annotations:
-        kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: sync-agent
     spec:
@@ -24,13 +17,13 @@ spec:
         runAsNonRoot: true
       containers:
       - command:
-        - /agent
+        - /syncer
         args:
-        - -control-plane-config-namespace=argocd
-        - -control-plane-config-name=mctc-control-plane
-        image: agent:latest
+        - -control-plane-config-namespace=mctc-system
+        - -control-plane-config-name=control-plane-cluster-internal
+        image: syncer:latest
         imagePullPolicy: Never
-        name: agent
+        name: syncer
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/hack/.argocdUtils
+++ b/hack/.argocdUtils
@@ -4,8 +4,53 @@ argocdAddCluster() {
     local hubCluster=$1
     local managedCluster=$2
 
-    makeSecretForCluster $managedCluster |
+    makeSecretForCluster $managedCluster $managedCluster $LOCAL_ACCESS |
     setNamespacedName argocd $managedCluster |
     setLabel argocd.argoproj.io/secret-type cluster | 
     kubectl apply --context kind-${hubCluster} -f -
+}
+
+
+CreateAgentSecret() {
+    local upstreamCluster=$1
+    local downstreamCluster=$2
+    local secretName=${downstreamCluster}
+    local internal=$3
+    local tmpfile=$(mktemp /tmp/kubeconfig-internal.XXXXXX)
+    if [ $internal == "true" ]; then
+        ${KIND_BIN} export kubeconfig --name ${upstreamCluster} --kubeconfig ${tmpfile}
+    else 
+        secretName=${downstreamCluster}-external
+        ${KIND_BIN} export kubeconfig --name ${upstreamCluster} --kubeconfig ${tmpfile}
+    fi
+    local server=$(kubectl --kubeconfig ${tmpfile} config view -o jsonpath="{$.clusters[?(@.name == 'kind-${upstreamCluster}')].cluster.server}")
+    local caData=$(kubectl --kubeconfig ${tmpfile} config view --raw -o jsonpath="{$.clusters[?(@.name == 'kind-${upstreamCluster}')].cluster.certificate-authority-data}")
+    local certData=$(kubectl --kubeconfig ${tmpfile} config view --raw -o jsonpath="{$.users[?(@.name == 'kind-${upstreamCluster}')].user.client-certificate-data}")
+    local keyData=$(kubectl --kubeconfig ${tmpfile} config view --raw -o jsonpath="{$.users[?(@.name == 'kind-${upstreamCluster}')].user.client-key-data}")
+    rm -f ${tmpfile}
+
+    kubectl create namespace mctc-system --context kind-${downstreamCluster} || true
+    cat <<EOF | kubectl apply --context kind-${downstreamCluster} -f -
+kind: Secret
+apiVersion: v1
+metadata:
+  name: ${secretName}
+  namespace: mctc-system
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+stringData:
+  config: >-
+    {
+      "tlsClientConfig":
+        {
+          "insecure": false,
+          "caData": "${caData}",
+          "certData": "${certData}",
+          "keyData": "${keyData}"
+        }
+    }
+  name: ${downstreamCluster}
+  server: ${server}
+type: Opaque
+EOF
 }

--- a/hack/.clusterUtils
+++ b/hack/.clusterUtils
@@ -4,9 +4,9 @@ makeSecretForCluster() {
   local clusterName=$1
   local targetCluster=$2
   local targetClusterName=${targetCluster:=$clusterName}
-  local localAccess=${LOCAL_ACCESS:="false"}
+  local localAccess=${3}
 
-  if [ $localAccess == "false" ]; then
+  if [ "$localAccess" != "true" ]; then
     internalFlag="--internal"
   fi
 

--- a/hack/gen-agent-secret.sh
+++ b/hack/gen-agent-secret.sh
@@ -9,7 +9,7 @@ set -e pipefail
 KIND_CLUSTER_PREFIX="mctc-"
 KIND_CLUSTER_CONTROL_PLANE="${KIND_CLUSTER_PREFIX}control-plane"
 
-makeSecretForCluster $KIND_CLUSTER_CONTROL_PLANE $(kubectl config current-context) |
+makeSecretForCluster $KIND_CLUSTER_CONTROL_PLANE $(kubectl config current-context) $LOCAL_ACCESS |
 setNamespacedName mctc-system control-plane-cluster |
 setLabel argocd.argoproj.io/secret-type cluster > config/agent/secret.yaml
 

--- a/hack/make/agent.make
+++ b/hack/make/agent.make
@@ -1,0 +1,35 @@
+AGENT_IMG ?= agent:$(TAG)
+
+.PHONY: build-agent
+build-agent: manifests generate fmt vet ## Build agent binary.
+	go build -o bin/agent ./cmd/agent/main.go
+
+.PHONY: run-agent
+run-agent: manifests generate fmt vet install
+	go run ./cmd/agent/main.go \
+	    --metrics-bind-address=:8082 \
+	    --health-probe-bind-address=:8083 \
+	    --control-plane-config-namespace=mctc-system
+
+.PHONY: docker-build-agent
+docker-build-agent: test ## Build docker image with the agent.
+	docker build --target agent -t ${AGENT_IMG} .
+	docker image prune -f --filter label=stage=mctc-builder
+
+.PHONY: kind-load-agent
+kind-load-agent: docker-build-agent
+	kind load docker-image ${AGENT_IMG} --name mctc-workload-1  --nodes mctc-workload-1-control-plane
+
+.PHONY: docker-push-agent
+docker-push-agent: ## Push docker image with the agent.
+	docker push ${AGENT_IMG}
+
+.PHONY: deploy-agent
+deploy-agent: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+	cd config/agent && $(KUSTOMIZE) edit set image agent=${AGENT_IMG}
+	$(KUSTOMIZE) build config/agent | kubectl apply -f -
+
+.PHONY: undeploy-agent
+undeploy-agent: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
+	$(KUSTOMIZE) build config/agent | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+

--- a/hack/make/controller.make
+++ b/hack/make/controller.make
@@ -1,0 +1,31 @@
+CONTROLLER_IMG ?= controller:$(TAG)
+
+.PHONY: build-controller
+build-controller: manifests generate fmt vet ## Build controller binary.
+	go build -o bin/controller ./cmd/controller/main.go
+
+.PHONY: run-controller
+run-controller: manifests generate fmt vet  install
+	go run ./cmd/controller/main.go
+
+.PHONY: docker-build-controller
+docker-build-controller: test ## Build docker image with the controller.
+	docker build --target controller -t ${CONTROLLER_IMG} .
+	docker image prune -f --filter label=stage=mctc-builder
+
+.PHONY: kind-load-controller
+kind-load-controller: docker-build-controller
+	kind load docker-image ${CONTROLLER_IMG} --name mctc-control-plane  --nodes mctc-control-plane-control-plane
+
+.PHONY: docker-push-controller
+docker-push-controller: ## Push docker image with the controller.
+	docker push ${CONTROLLER_IMG}
+
+.PHONY: deploy-controller
+deploy-controller: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${CONTROLLER_IMG}
+	$(KUSTOMIZE) --load-restrictor LoadRestrictionsNone build config/deploy/local | kubectl apply -f -
+
+.PHONY: undeploy-controller
+undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
+	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -

--- a/hack/make/dependencies.make
+++ b/hack/make/dependencies.make
@@ -1,0 +1,57 @@
+##@ Build Dependencies
+
+## Location to install dependencies to
+LOCALBIN ?= $(shell pwd)/bin
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
+
+## Tool Binaries
+KUSTOMIZE ?= $(LOCALBIN)/kustomize
+CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
+ENVTEST ?= $(LOCALBIN)/setup-envtest
+KIND ?= $(LOCALBIN)/kind
+HELM ?= $(LOCALBIN)/helm
+
+## Tool Versions
+KUSTOMIZE_VERSION ?= v4.5.4
+CONTROLLER_TOOLS_VERSION ?= v0.10.0
+KIND_VERSION ?= v0.14.0
+HELM_VERSION ?= v3.10.0
+YQ_VERSION ?= v4.30.8
+
+KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
+.PHONY: kustomize
+kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.
+$(KUSTOMIZE): $(LOCALBIN)
+	@if test -x $(LOCALBIN)/kustomize && ! $(LOCALBIN)/kustomize version | grep -q $(KUSTOMIZE_VERSION); then \
+		echo "$(LOCALBIN)/kustomize version is not expected $(KUSTOMIZE_VERSION). Removing it before installing."; \
+		rm -rf $(LOCALBIN)/kustomize; \
+	fi
+	test -s $(LOCALBIN)/kustomize || { curl -Ss $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); }
+
+.PHONY: controller-gen
+controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary. If wrong version is installed, it will be overwritten.
+$(CONTROLLER_GEN): $(LOCALBIN)
+	test -s $(LOCALBIN)/controller-gen && $(LOCALBIN)/controller-gen --version | grep -q $(CONTROLLER_TOOLS_VERSION) || \
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
+
+.PHONY: envtest
+envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
+$(ENVTEST): $(LOCALBIN)
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+
+.PHONY: kind
+kind: $(KIND) ## Download kind locally if necessary.
+$(KIND):
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/kind@$(KIND_VERSION)
+
+HELM_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3"
+.PHONY: helm
+helm: $(HELM)
+$(HELM):
+	curl -s $(HELM_INSTALL_SCRIPT) | HELM_INSTALL_DIR=$(LOCALBIN) PATH=$$PATH:$$HELM_INSTALL_DIR bash -s -- --no-sudo --version $(HELM_VERSION)
+
+.PHONY: yq
+yq: $(YQ)
+	test -s $(LOCALBIN)/yq || GOBIN=$(LOCALBIN) go install github.com/mikefarah/yq/v4@$(YQ_VERSION)
+

--- a/hack/make/syncer.make
+++ b/hack/make/syncer.make
@@ -1,0 +1,36 @@
+SYNCER_IMG ?= syncer:$(TAG)
+
+.PHONY: build-syncer
+build-syncer: manifests generate fmt vet ## Build syncer binary.
+	go build -o bin/syncer ./cmd/syncer/main.go
+
+.PHONY: run-syncer
+run-syncer: manifests generate fmt vet install
+	go run ./cmd/syncer/main.go \
+	    --metrics-bind-address=:8084 \
+	    --health-probe-bind-address=:8085 \
+	    --control-plane-config-name=control-plane-cluster \
+	    --control-plane-config-namespace=mctc-system \
+	    --synced-resources=gateways.v1beta1.gateway.networking.k8s.io
+
+.PHONY: docker-build-syncer
+docker-build-syncer: test ## Build docker image with the syncer.
+	docker build --target syncer -t ${SYNCER_IMG} .
+	docker image prune -f --filter label=stage=mctc-builder
+
+.PHONY: kind-load-syncer
+kind-load-syncer: docker-build-syncer
+	kind load docker-image ${SYNCER_IMG} --name mctc-workload-1  --nodes mctc-workload-1-control-plane
+
+.PHONY: docker-push-syncer
+docker-push-syncer: ## Push docker image with the syncer.
+	docker push ${SYNCER_IMG}
+
+.PHONY: deploy-syncer
+deploy-syncer: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+	cd config/syncer && $(KUSTOMIZE) edit set image syncer=${SYNCER_IMG}
+	$(KUSTOMIZE) build config/syncer | kubectl apply -f -
+
+.PHONY: undeploy-syncer
+undeploy-syncer: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
+	$(KUSTOMIZE) build config/syncer | kubectl delete --ignore-not-found=$(ignore-not-found) -f -

--- a/pkg/syncer/spec/controller.go
+++ b/pkg/syncer/spec/controller.go
@@ -1,0 +1,335 @@
+package spec
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/json"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	controllerName                      = "mctc-spec-syncing-controller"
+	SyncerFinalizerNamePrefix           = "mctc-spec-syncer-finalizer-"
+	SyncerDeletionAnnotationPrefix      = "mctc-spec-syncer-deletion-timestamp-"
+	SyncerClusterStatusAnnotationPrefix = "mctc-spec-syncer-status-"
+	syncerApplyManager                  = "syncer"
+	downstreamNamespace                 = "mctc-downstream"
+)
+
+type Controller struct {
+	queue workqueue.RateLimitingInterface
+
+	upstreamClient   dynamic.Interface
+	downstreamClient dynamic.Interface
+
+	syncTargetName string
+	syncTargetKey  string
+}
+
+func NewSpecSyncer(syncTargetName, syncTargetKey string, upstreamClient dynamic.Interface, downstreamClient dynamic.Interface) (*Controller, error) {
+	c := &Controller{
+		queue:            workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerName),
+		upstreamClient:   upstreamClient,
+		downstreamClient: downstreamClient,
+		syncTargetName:   syncTargetName,
+		syncTargetKey:    syncTargetKey,
+	}
+
+	return c, nil
+}
+
+type queueKey struct {
+	gvr schema.GroupVersionResource
+	key string // meta namespace key
+}
+
+func (c *Controller) AddToQueue(gvr schema.GroupVersionResource, obj interface{}) {
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+
+	c.queue.Add(
+		queueKey{
+			gvr: gvr,
+			key: key,
+		},
+	)
+}
+
+// Start starts N worker processes each processing work items.
+func (c *Controller) Start(ctx context.Context, numThreads int) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	for i := 0; i < numThreads; i++ {
+		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
+	}
+
+	<-ctx.Done()
+}
+
+// startWorker processes work items until stopCh is closed.
+func (c *Controller) startWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *Controller) processNextWorkItem(ctx context.Context) bool {
+	// Wait until there is a new item in the working queue
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	qk := key.(queueKey)
+
+	// No matter what, tell the queue we're done with this key, to unblock
+	// other workers.
+	defer c.queue.Done(key)
+
+	retryAfter, err := c.process(ctx, qk.gvr, qk.key)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("%s failed to sync %q, err: %w", controllerName, key, err))
+		c.queue.AddRateLimited(key)
+		return true
+	} else if retryAfter != nil {
+		c.queue.AddAfter(key, *retryAfter)
+		return true
+	}
+
+	c.queue.Forget(key)
+
+	return true
+}
+
+func (c *Controller) process(ctx context.Context, gvr schema.GroupVersionResource, key string) (retryAfter *time.Duration, err error) {
+	logger := log.FromContext(ctx)
+	logger.Info("sync controller process", "key", key, "gvr", gvr.String())
+	// from upstream
+	upstreamNamespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		logger.Error(err, "Invalid key")
+		return nil, nil
+	}
+
+	downstreamNamespace := downstreamNamespace
+
+	// get the upstream object
+	upstreamUnstructuredObject, err := c.upstreamClient.Resource(gvr).Namespace(upstreamNamespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		logger.Error(err, "error finding upstream object")
+		return nil, err
+	} else if errors.IsNotFound(err) {
+		logger.Info("upstream object not found.", "gvr", gvr, "namespace", upstreamNamespace, "name", name)
+		// deleted upstream => delete downstream
+		logger.Info("Deleting downstream object for upstream object")
+		err = c.downstreamClient.Resource(gvr).Namespace(downstreamNamespace).Delete(ctx, name, metav1.DeleteOptions{})
+		if err != nil && !errors.IsNotFound(err) {
+			return nil, err
+		}
+		//TODO If the resource is namespaced, let's plan the cleanup of it's namespace.
+		return nil, nil
+	}
+
+	// upsert downstream
+	if err := c.ensureDownstreamNamespaceExists(ctx, downstreamNamespace); err != nil {
+		return nil, err
+	}
+
+	if added, err := c.ensureSyncerFinalizer(ctx, gvr, upstreamUnstructuredObject); added {
+		// The successful update of the upstream resource finalizer will trigger a new reconcile
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	return nil, c.applyToDownstream(ctx, gvr, downstreamNamespace, upstreamUnstructuredObject)
+}
+
+func (c *Controller) ensureDownstreamNamespaceExists(ctx context.Context, downstreamNamespace string) error {
+	logger := log.FromContext(ctx)
+
+	namespaces := c.downstreamClient.Resource(schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "namespaces",
+	})
+
+	newNamespace := &unstructured.Unstructured{}
+	newNamespace.SetAPIVersion("v1")
+	newNamespace.SetKind("Namespace")
+	newNamespace.SetName(downstreamNamespace)
+
+	_, err := namespaces.Create(ctx, newNamespace, metav1.CreateOptions{})
+	if err == nil || !errors.IsAlreadyExists(err) {
+		logger.Info("Created downstream namespace for upstream namespace")
+		return nil
+	}
+
+	return nil
+}
+
+func (c *Controller) ensureSyncerFinalizer(ctx context.Context, gvr schema.GroupVersionResource, upstreamObj *unstructured.Unstructured) (bool, error) {
+	logger := log.FromContext(ctx)
+
+	upstreamFinalizers := upstreamObj.GetFinalizers()
+	hasFinalizer := false
+	for _, finalizer := range upstreamFinalizers {
+		if finalizer == SyncerFinalizerNamePrefix+c.syncTargetKey {
+			hasFinalizer = true
+		}
+	}
+
+	intendedToBeRemovedFromLocation := upstreamObj.GetAnnotations()[SyncerDeletionAnnotationPrefix+c.syncTargetKey] != ""
+
+	stillOwnedByExternalActorForLocation := upstreamObj.GetAnnotations()[SyncerFinalizerNamePrefix+c.syncTargetKey] != ""
+
+	if !hasFinalizer && (!intendedToBeRemovedFromLocation || stillOwnedByExternalActorForLocation) {
+		upstreamObjCopy := upstreamObj.DeepCopy()
+		namespace := upstreamObjCopy.GetNamespace()
+
+		upstreamFinalizers = append(upstreamFinalizers, SyncerFinalizerNamePrefix+c.syncTargetKey)
+		upstreamObjCopy.SetFinalizers(upstreamFinalizers)
+		if _, err := c.upstreamClient.Resource(gvr).Namespace(namespace).Update(ctx, upstreamObjCopy, metav1.UpdateOptions{}); err != nil {
+			logger.Error(err, "Failed adding finalizer on upstream upstreamresource")
+			return false, err
+		}
+		logger.Info("Updated upstream resource with syncer finalizer")
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (c *Controller) applyToDownstream(ctx context.Context, gvr schema.GroupVersionResource, downstreamNamespace string, upstreamObj *unstructured.Unstructured) error {
+	logger := log.FromContext(ctx)
+
+	downstreamObj := upstreamObj.DeepCopy()
+
+	intendedToBeRemovedFromLocation := upstreamObj.GetAnnotations()[SyncerDeletionAnnotationPrefix+c.syncTargetKey] != ""
+
+	stillOwnedByExternalActorForLocation := upstreamObj.GetAnnotations()[SyncerFinalizerNamePrefix+c.syncTargetKey] != ""
+
+	if intendedToBeRemovedFromLocation && !stillOwnedByExternalActorForLocation {
+		var err error
+		if downstreamNamespace != "" {
+			err = c.downstreamClient.Resource(gvr).Namespace(downstreamNamespace).Delete(ctx, downstreamObj.GetName(), metav1.DeleteOptions{})
+		} else {
+			err = c.downstreamClient.Resource(gvr).Delete(ctx, downstreamObj.GetName(), metav1.DeleteOptions{})
+		}
+		if err != nil {
+			if errors.IsNotFound(err) {
+				// That's not an error.
+				// Just think about removing the finalizer from the KCP location-specific resource:
+				return c.EnsureUpstreamFinalizerRemoved(ctx, gvr, upstreamObj.GetNamespace(), upstreamObj.GetName())
+			}
+			logger.Error(err, "Error deleting upstream resource from downstream")
+			return err
+		}
+		//TODO clean up namespace
+		logger.Info("Deleted upstream resource from downstream")
+		return nil
+	}
+
+	//TODO jsonpatch applied
+
+	downstreamObj.SetUID("")
+	downstreamObj.SetResourceVersion("")
+	downstreamObj.SetNamespace(downstreamNamespace)
+	downstreamObj.SetManagedFields(nil)
+
+	// Strip cluster name annotation
+	downstreamAnnotations := downstreamObj.GetAnnotations()
+	delete(downstreamAnnotations, SyncerClusterStatusAnnotationPrefix+c.syncTargetKey)
+
+	// If we're left with 0 annotations, nil out the map so it's not included in the patch
+	if len(downstreamAnnotations) == 0 {
+		downstreamAnnotations = nil
+	}
+	downstreamObj.SetAnnotations(downstreamAnnotations)
+
+	// Deletion fields are immutable and set by the downstream API server
+	downstreamObj.SetDeletionTimestamp(nil)
+	downstreamObj.SetDeletionGracePeriodSeconds(nil)
+	// Strip owner references, to avoid orphaning by broken references,
+	// and make sure cascading deletion is only performed once upstream.
+	downstreamObj.SetOwnerReferences(nil)
+	// Strip finalizers to avoid the deletion of the downstream resource from being blocked.
+	downstreamObj.SetFinalizers(nil)
+
+	// replace upstream state label with downstream cluster label. We don't want to leak upstream state machine
+	// state to downstream, and also we don't need downstream updates every time the upstream state machine changes.
+	labels := downstreamObj.GetLabels()
+	downstreamObj.SetLabels(labels)
+
+	// Marshalling the unstructured object is good enough as SSA patch
+	data, err := json.Marshal(downstreamObj)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.downstreamClient.Resource(gvr).Namespace(downstreamNamespace).Patch(ctx, downstreamObj.GetName(), types.ApplyPatchType, data, metav1.PatchOptions{FieldManager: syncerApplyManager, Force: pointer.Bool(true)})
+
+	if err != nil {
+		logger.Error(err, "Error upserting upstream resource to downstream")
+		return err
+	}
+	logger.Info("Upserted upstream resource to downstream")
+
+	return nil
+}
+
+func (c *Controller) EnsureUpstreamFinalizerRemoved(ctx context.Context, gvr schema.GroupVersionResource, upstreamNamespace string, resourceName string) error {
+	logger := log.FromContext(ctx)
+
+	upstreamObj, err := c.upstreamClient.Resource(gvr).Namespace(upstreamNamespace).Get(ctx, resourceName, metav1.GetOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	if errors.IsNotFound(err) {
+		return nil
+	}
+
+	if upstreamObj.GetAnnotations()[SyncerDeletionAnnotationPrefix+c.syncTargetKey] == "" {
+		// Do nothing: the object should not be deleted anymore for this location on the KCP side
+		return nil
+	}
+
+	upstreamObj = upstreamObj.DeepCopy()
+
+	// Remove the syncer finalizer.
+	currentFinalizers := upstreamObj.GetFinalizers()
+	var desiredFinalizers []string
+	for _, finalizer := range currentFinalizers {
+		if finalizer != SyncerFinalizerNamePrefix+c.syncTargetKey {
+			desiredFinalizers = append(desiredFinalizers, finalizer)
+		}
+	}
+	upstreamObj.SetFinalizers(desiredFinalizers)
+	annotations := upstreamObj.GetAnnotations()
+	delete(annotations, SyncerClusterStatusAnnotationPrefix+c.syncTargetKey)
+	delete(annotations, SyncerDeletionAnnotationPrefix+c.syncTargetKey)
+	upstreamObj.SetAnnotations(annotations)
+
+	_, err = c.upstreamClient.Resource(gvr).Namespace(upstreamObj.GetNamespace()).Update(ctx, upstreamObj, metav1.UpdateOptions{})
+	if err != nil {
+		logger.Error(err, "Failed updating upstream resource after removing the syncer finalizer")
+		return err
+	}
+	logger.Info("Updated upstream resource to remove the syncer finalizer")
+	return nil
+}

--- a/pkg/syncer/sync.go
+++ b/pkg/syncer/sync.go
@@ -1,0 +1,115 @@
+package syncer
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/_internal/metadata"
+	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/_internal/slice"
+)
+
+const (
+	MCTC_SYNC_ANNOTATION_PREFIX   = "mctc-sync-agent/"
+	MCTC_SYNC_ANNOTATION_WILDCARD = "all"
+)
+
+type Syncer interface {
+	Handle(unstructured unstructured.Unstructured) error
+}
+
+type Config struct {
+	UpstreamClientConfig *rest.Config
+	DownStreamClient     client.Client
+	ClusterID            string
+	GVRs                 []string
+	InformerFactory      dynamicinformer.DynamicSharedInformerFactory
+	NeverSyncedGVRs      []string
+	UpstreamNS           string
+	DownstreamNS         string
+	Syncer               Syncer
+}
+
+type InformerEventsDecorator func(cfg Config, informer informers.GenericInformer, gvr *schema.GroupVersionResource, c SyncController) error
+
+type SyncController interface {
+	AddToQueue(schema.GroupVersionResource, interface{})
+}
+
+func StartSyncers(ctx context.Context, cfg Config, informerEventDecorator InformerEventsDecorator, c SyncController) error {
+	for _, gvrStr := range cfg.GVRs {
+		// Some GVRs should never be synced (e.g. 'pods')
+		if slice.ContainsString(cfg.NeverSyncedGVRs, gvrStr) {
+			continue
+		}
+		gvr, _ := schema.ParseResourceArg(gvrStr)
+		informer := cfg.InformerFactory.ForResource(*gvr)
+		err := informerEventDecorator(cfg, informer, gvr, c)
+		if err != nil {
+			return fmt.Errorf("error decorating informer for GVR events: %v", err.Error())
+		}
+		informer.Informer().Run(ctx.Done())
+	}
+	return nil
+}
+
+// InformerForGVR is an informer Decorator which adds generic event handlers to an informer
+func InformerForGVR(cfg Config, informer informers.GenericInformer, gvr *schema.GroupVersionResource, c SyncController) error {
+	_, err := informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(objInterface interface{}) {
+			metaAccessor, err := meta.Accessor(objInterface)
+			if err != nil {
+				return
+			}
+			value := metadata.GetAnnotation(metaAccessor, MCTC_SYNC_ANNOTATION_PREFIX+cfg.ClusterID)
+			if value != "true" {
+				// no specific annotation for this cluster, is a wildcard annotation present?
+				value = metadata.GetAnnotation(metaAccessor, MCTC_SYNC_ANNOTATION_PREFIX+MCTC_SYNC_ANNOTATION_WILDCARD)
+				if value != "true" {
+					return
+				}
+			}
+
+			c.AddToQueue(*gvr, objInterface)
+		},
+		UpdateFunc: func(oldObjInterface, newObjInterface interface{}) {
+			metaAccessor, err := meta.Accessor(newObjInterface)
+			if err != nil {
+				return
+			}
+			value := metadata.GetAnnotation(metaAccessor, MCTC_SYNC_ANNOTATION_PREFIX+cfg.ClusterID)
+			if value != "true" {
+				// no specific annotation for this cluster, is a wildcard annotation present?
+				value = metadata.GetAnnotation(metaAccessor, MCTC_SYNC_ANNOTATION_PREFIX+MCTC_SYNC_ANNOTATION_WILDCARD)
+				if value != "true" {
+					return
+				}
+			}
+			c.AddToQueue(*gvr, newObjInterface)
+		},
+		DeleteFunc: func(objInterface interface{}) {
+			metaAccessor, err := meta.Accessor(objInterface)
+			if err != nil {
+				return
+			}
+			value := metadata.GetAnnotation(metaAccessor, MCTC_SYNC_ANNOTATION_PREFIX+cfg.ClusterID)
+			if value != "true" {
+				// no specific annotation for this cluster, is a wildcard annotation present?
+				value = metadata.GetAnnotation(metaAccessor, MCTC_SYNC_ANNOTATION_PREFIX+MCTC_SYNC_ANNOTATION_WILDCARD)
+				if value != "true" {
+					return
+				}
+			}
+			c.AddToQueue(*gvr, objInterface)
+		},
+	})
+	return err
+}


### PR DESCRIPTION
## Verification:
### setup
- `export LOCAL_ACCESS="true"`
- run a fresh: `make local-setup MCTC_WORKLOAD_CLUSTERS_COUNT=1`
- open 3 terminals
  - in terminal 1 target the control plane: `export KUBECONFIG=./tmp/kubeconfigs/mctc-control-plane.kubeconfig`
  - in terminal 2 and 3 target the workload cluster: `export KUBECONFIG=./tmp/kubeconfigs/mctc-workload-1.kubeconfig`
- in terminal 2, run: `make run-syncer`

### assert annotation is required
- in terminal 1: `kubectl create -f config/samples/gateway.yaml`
- **expectation:** nothing should happen

### assert annotation is observed
- in terminal 1: edit the gateway and add the annotation: `mctc-sync-agent/kind-mctc-workload-1: "true"`
- there should be activity in terminal 2
- in terminal 3: `kubectl get gateway example-gateway -n mctc-downstream -o yaml`
- **expectation:** The  gateway should be present in the downstream cluster

### assert updates are applied
- in terminal 1: edit the spec of the gateway
- there should be activity in terminal 2
- in terminal 3: `kubectl get gateway example-gateway -n mctc-downstream -o yaml`
- **expectation:** the gateway spec should update to match the change

## Notes
- deletion is not implemented
- patch annotations are not implemented
- the downstream namespace is hardcoded `mctc-downstream`
- status syncing up is not implemented
- A lot of this code is airlifted from the KCP syncer, and modified, in some cases to simplify it, in some cases to refactor away from the expectation of workspaces.