### PR TITLE
Deploy dumb syncer

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -119,9 +119,7 @@ func main() {
 	}
 
 	syncerContext, cancel := context.WithCancel(context.Background())
-	defer func() {
-		cancel()
-	}()
+	defer cancel()
 	syncRunnable, err := startSyncers(syncerContext, syncedResources, client.ObjectKey{Namespace: controlPlaneConfigSecretNamespace, Name: controlPlaneConfigSecretName}, mgr)
 	if err != nil {
 		setupLog.Error(err, "unable to start syncers")

--- a/config/syncer/role.yaml
+++ b/config/syncer/role.yaml
@@ -6,15 +6,6 @@ metadata:
   name: agent-role
 rules:
 - apiGroups:
-  - "networking.k8s.io"
-  resources:
-  - ingresses
-  verbs:
-  - get
-  - update
-  - watch
-  - list
-- apiGroups:
   - ""
   resources:
   - configmaps
@@ -46,3 +37,28 @@ rules:
   verbs:
   - create
   - patch
+
+- apiGroups:
+    - "gateway.networking.k8s.io"
+  resources:
+    - gateways
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+- apiGroups:
+    - ""
+  resources:
+    - namespaces
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete

--- a/config/syncer/syncer.yaml
+++ b/config/syncer/syncer.yaml
@@ -21,6 +21,7 @@ spec:
         args:
         - -control-plane-config-namespace=mctc-system
         - -control-plane-config-name=control-plane-cluster-internal
+        - -synced-resources=gateways.v1beta1.gateway.networking.k8s.io
         image: syncer:latest
         imagePullPolicy: Never
         name: syncer

--- a/hack/make/syncer.make
+++ b/hack/make/syncer.make
@@ -14,7 +14,7 @@ run-syncer: manifests generate fmt vet install
 	    --synced-resources=gateways.v1beta1.gateway.networking.k8s.io
 
 .PHONY: docker-build-syncer
-docker-build-syncer: test ## Build docker image with the syncer.
+docker-build-syncer: ## Build docker image with the syncer.
 	docker build --target syncer -t ${SYNCER_IMG} .
 	docker image prune -f --filter label=stage=mctc-builder
 
@@ -34,3 +34,6 @@ deploy-syncer: manifests kustomize ## Deploy controller to the K8s cluster speci
 .PHONY: undeploy-syncer
 undeploy-syncer: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/syncer | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+
+.PHONY: redeploy-syncer
+redeploy-syncer: undeploy-syncer deploy-syncer

--- a/pkg/syncer/spec/controller.go
+++ b/pkg/syncer/spec/controller.go
@@ -27,6 +27,7 @@ const (
 	SyncerClusterStatusAnnotationPrefix = "mctc-spec-syncer-status-"
 	syncerApplyManager                  = "syncer"
 	downstreamNamespace                 = "mctc-downstream"
+	NUM_THREADS                         = 1
 )
 
 type Controller struct {
@@ -72,11 +73,11 @@ func (c *Controller) AddToQueue(gvr schema.GroupVersionResource, obj interface{}
 }
 
 // Start starts N worker processes each processing work items.
-func (c *Controller) Start(ctx context.Context, numThreads int) {
+func (c *Controller) Start(ctx context.Context) {
 	defer utilruntime.HandleCrash()
 	defer c.queue.ShutDown()
 
-	for i := 0; i < numThreads; i++ {
+	for i := 0; i < NUM_THREADS; i++ {
 		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
 	}
 

--- a/pkg/syncer/spec/controller.go
+++ b/pkg/syncer/spec/controller.go
@@ -126,8 +126,6 @@ func (c *Controller) process(ctx context.Context, gvr schema.GroupVersionResourc
 		return nil, nil
 	}
 
-	downstreamNamespace := downstreamNamespace
-
 	// get the upstream object
 	upstreamUnstructuredObject, err := c.upstreamClient.Resource(gvr).Namespace(upstreamNamespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil && !errors.IsNotFound(err) {


### PR DESCRIPTION
## Summary
The manager from kubebuilder was exiting immediately because as far as it was concerned it had no tasks to run. This PR converts the syncer informers to run as a mgr task so that the manager does not exit too early.

## Verification:
### setup
- `export LOCAL_ACCESS="true"`
- run a fresh: `make local-setup MCTC_WORKLOAD_CLUSTERS_COUNT=1`
- open 3 terminals
  - in terminal 1 target the control plane: `export KUBECONFIG=./tmp/kubeconfigs/mctc-control-plane.kubeconfig`
  - in terminal 2 and 3 target the workload cluster: `export KUBECONFIG=./tmp/kubeconfigs/mctc-workload-1.kubeconfig`
- in terminal 2, run: 
  - `make kind-load-syncer`
  - `make deploy-syncer`

### assert annotation is required
- in terminal 1: `kubectl create -f config/samples/gateway.yaml`
- **expectation:** nothing should happen

### assert annotation is observed
- in terminal 1: edit the gateway and add the annotation: `mctc-sync-agent/kind-mctc-workload-1: "true"`
- there should be activity in terminal 2
- in terminal 3: `kubectl get gateway example-gateway -n mctc-downstream -o yaml`
- **expectation:** The  gateway should be present in the downstream cluster

### assert updates are applied
- in terminal 1: edit the spec of the gateway
- there should be activity in terminal 2
- in terminal 3: `kubectl get gateway example-gateway -n mctc-downstream -o yaml`
- **expectation:** the gateway spec should update to match the change