### PR TITLE
#44: Cluster registration

### DIFF
--- a/config/syncer-control/kustomization.yaml
+++ b/config/syncer-control/kustomization.yaml
@@ -1,0 +1,10 @@
+# Resources to be created in the tenant namespace in the control plane
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- role.yaml
+- rolebinding.yaml
+- serviceaccount.yaml
+
+namespace: tenant

--- a/config/syncer-control/role.yaml
+++ b/config/syncer-control/role.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: syncer
+  namespace: system
+rules:
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gateways
+  verbs:
+  - get
+  - update
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch

--- a/config/syncer-control/rolebinding.yaml
+++ b/config/syncer-control/rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: syncer
+  namespace: system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: syncer
+subjects:
+- kind: ServiceAccount
+  name: syncer
+  namespace: system

--- a/config/syncer-control/serviceaccount.yaml
+++ b/config/syncer-control/serviceaccount.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: syncer
+  namespace: system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: syncer-token
+  namespace: system
+  annotations:
+    kubernetes.io/service-account.name: syncer
+type: kubernetes.io/service-account-token  

--- a/config/syncer/.gitignore
+++ b/config/syncer/.gitignore
@@ -1,0 +1,1 @@
+secret.yaml

--- a/config/syncer/kustomization.yaml
+++ b/config/syncer/kustomization.yaml
@@ -5,9 +5,19 @@ resources:
 - serviceaccount.yaml
 - rolebinding.yaml
 - syncer.yaml
+- secret.yaml
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: syncer
   newName: syncer
   newTag: latest
+
+patches:
+- path: syncer_parameter_patch.json
+  target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: sync-agent

--- a/config/syncer/syncer_parameter_patch.json
+++ b/config/syncer/syncer_parameter_patch.json
@@ -1,0 +1,12 @@
+[
+  {
+    "op": "add",
+    "path": "/spec/template/spec/containers/0/args/3",
+    "value": "--control-plane-namespace"
+  },
+  {
+    "op": "add",
+    "path": "/spec/template/spec/containers/0/args/4",
+    "value": ""
+  }
+]

--- a/hack/.clusterUtils
+++ b/hack/.clusterUtils
@@ -1,22 +1,15 @@
 # shellcheck shell=bash
 
-makeSecretForCluster() {
-  local clusterName=$1
-  local targetCluster=$2
+makeSecretForKubeconfig() {
+  local kubeconfig=$1
+  local clusterName=$2
+  local targetCluster=$3
   local targetClusterName=${targetCluster:=$clusterName}
-  local localAccess=${3}
 
-  if [ "$localAccess" != "true" ]; then
-    internalFlag="--internal"
-  fi
-
-  local tmpfile=$(mktemp /tmp/kubeconfig-internal.XXXXXX)
-  ${KIND_BIN} export kubeconfig -q $internalFlag --name ${clusterName} --kubeconfig ${tmpfile}
-  local server=$(kubectl --kubeconfig ${tmpfile} config view -o jsonpath="{$.clusters[?(@.name == 'kind-${clusterName}')].cluster.server}")
-  local caData=$(kubectl --kubeconfig ${tmpfile} config view --raw -o jsonpath="{$.clusters[?(@.name == 'kind-${clusterName}')].cluster.certificate-authority-data}")
-  local certData=$(kubectl --kubeconfig ${tmpfile} config view --raw -o jsonpath="{$.users[?(@.name == 'kind-${clusterName}')].user.client-certificate-data}")
-  local keyData=$(kubectl --kubeconfig ${tmpfile} config view --raw -o jsonpath="{$.users[?(@.name == 'kind-${clusterName}')].user.client-key-data}")
-  rm -f ${tmpfile}
+  local server=$(kubectl --kubeconfig ${kubeconfig} config view -o jsonpath="{$.clusters[?(@.name == '${clusterName}')].cluster.server}")
+  local caData=$(kubectl --kubeconfig ${kubeconfig} config view --raw -o jsonpath="{$.clusters[?(@.name == '${clusterName}')].cluster.certificate-authority-data}")
+  local certData=$(kubectl --kubeconfig ${kubeconfig} config view --raw -o jsonpath="{$.users[?(@.name == '${clusterName}')].user.client-certificate-data}")
+  local keyData=$(kubectl --kubeconfig ${kubeconfig} config view --raw -o jsonpath="{$.users[?(@.name == '${clusterName}')].user.client-key-data}")
 
   cat <<EOF
 kind: Secret
@@ -39,6 +32,24 @@ stringData:
   server: ${server}
 type: Opaque
 EOF
+
+}
+
+makeSecretForCluster() {
+  local clusterName=$1
+  local targetCluster=$2
+  local targetClusterName=${targetCluster:=$clusterName}
+  local localAccess=${3}
+
+  if [ "$localAccess" != "true" ]; then
+    internalFlag="--internal"
+  fi
+
+  local tmpfile=$(mktemp /tmp/kubeconfig-internal.XXXXXX)
+  ${KIND_BIN} export kubeconfig -q $internalFlag --name ${clusterName} --kubeconfig ${tmpfile}
+
+  makeSecretForKubeconfig $tmpfile kind-$clusterName $targetCluster $targetClusterName
+  rm -f $tmpfile
 }
 
 setNamespacedName() {
@@ -51,4 +62,14 @@ setLabel() {
   label=$1
   value=$2
   cat /dev/stdin | ${YQ_BIN} '.metadata.labels."'$label'"="'$value'"'
+}
+
+setConfig() {
+  expr=$1
+
+  cp /dev/stdin /tmp/doctmp
+  config=$(cat /tmp/doctmp | ${YQ_BIN} '.stringData.config')
+  updatedConfig=$(echo $config | ${YQ_BIN} -P $expr -o=json)
+
+  cat /tmp/doctmp | cfg=$updatedConfig ${YQ_BIN} '.stringData.config=strenv(cfg)'
 }

--- a/hack/.kindUtils
+++ b/hack/.kindUtils
@@ -27,4 +27,5 @@ nodes:
 EOF
 mkdir -p ./tmp/kubeconfigs
 ${KIND_BIN} get kubeconfig --name ${cluster} > ./tmp/kubeconfigs/${cluster}.kubeconfig
+${KIND_BIN} export kubeconfig --name ${cluster} --kubeconfig ./tmp/kubeconfigs/internal/${cluster}.kubeconfig --internal
 }

--- a/hack/register-cluster.sh
+++ b/hack/register-cluster.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+### Usage
+### export KUBECONFIG=$(pwd)/tmp/kubeconfigs/mctc-control-plane.kubeconfig
+### register-cluster.sh <PATH TO CONTROL CLUSTER KUBECONFIG> <PATH TO TENANT CLUSTER KUBECONFIG> <TENANT NAMESPACE> <NAME OF THE TENANT CLUSTER> > agent-manifests.yaml
+###
+### Outputs the manifests to deploy the syncer in the tenant cluster
+
+LOCAL_SETUP_DIR="$(dirname "${BASH_SOURCE[0]}")"
+source "${LOCAL_SETUP_DIR}"/.setupEnv
+source "${LOCAL_SETUP_DIR}"/.clusterUtils
+source "${LOCAL_SETUP_DIR}"/.argocdUtils
+
+controlClusterKubeconfig=$1
+clusterKubeconfig=$2
+tenantNs=$3
+clusterName=$4
+
+# Validate that Gateway API is installed in the tenant cluster
+if ! kubectl --kubeconfig $clusterKubeconfig get crd/gateways.gateway.networking.k8s.io > /dev/null ; then
+  echo "Gateway API not found in tenant cluster" > /dev/stderr
+  exit 1
+fi
+
+# Create ArgoCD secret for cluster in control plane
+makeSecretForKubeconfig $clusterKubeconfig $clusterName |
+setNamespacedName argocd $clusterName |
+setLabel argocd.argoproj.io/secret-type cluster |
+kubectl apply -f - > /dev/null
+
+# Create SA in tenant ns
+cd ${LOCAL_SETUP_DIR}/../config/syncer-control
+${KUSTOMIZE_BIN} edit set namespace $tenantNs
+${KUSTOMIZE_BIN} build . | kubectl apply -f - > /dev/null
+cd ../../
+
+# Get the token for the SA
+export saToken=$(kubectl get secret/syncer-token -n $tenantNs -o go-template="{{.data.token | base64decode}}")
+
+
+# Create secret to access control cluster in workload cluster
+makeSecretForKubeconfig $controlClusterKubeconfig kind-mctc-control-plane $clusterName |
+setNamespacedName mctc-system control-plane-cluster-internal |
+setLabel argocd.argoproj.io/secret-type cluster |
+setConfig '.bearerToken=strenv(saToken)' > ${LOCAL_SETUP_DIR}/../config/syncer/secret.yaml
+
+# Set the --control-plane-namespace flag in the agent deployment to the tenant
+# namespace
+${YQ_BIN} -i -P -o=json '.[1].value = "'$tenantNs'"' ${LOCAL_SETUP_DIR}/../config/syncer/syncer_parameter_patch.json
+
+# Output deployment manifests
+${KUSTOMIZE_BIN} build ${LOCAL_SETUP_DIR}/../config/syncer


### PR DESCRIPTION
## Description

> Closes #44 

Cluster registration script

## Verification steps

1. Run local-setup with only the control cluster
	```sh
	make local-setup
	```

1. Create the tenant namespace in the control cluster
	```sh
	kubectl create namespace my-tenant
	```

1. Create the tenant cluster
	```sh
	# Import the util scripts
	source hack/.setupEnv
	source hack/.kindUtils

	kindCreateCluster tenant-cluster 9091 8446
	```

1. Install Gateway API in the tenant cluster
	```sh
	export KUBECONFIG=$(pwd)/tmp/kubeconfigs/tenant-cluster.kubeconfig
	./bin/kustomize build config/gateway-api | kubectl apply -f -
	```

1. Run the register cluster script
	```sh
	export KUBECONFIG=$(pwd)/tmp/kubeconfigs/mctc-control-plane.kubeconfig
	kubectl config use-context kind-mctc-control-plane
	./hack/register-cluster.sh $(pwd)/tmp/kubeconfigs/internal/mctc-control-plane.kubeconfig $(pwd)/tmp/kubeconfigs/tenant-cluster.kubeconfig my-tenant kind-tenant-cluster > agent-manifests.yaml
	```

3. Deploy the syncer in the tenant cluster
	```sh
	# Build and load the syncer image
	make docker-build-syncer
	kind load docker-image syncer:latest --name tenant-cluster  --nodes tenant-cluster-control-plane

	export KUBECONFIG=$(pwd)/tmp/kubeconfigs/tenant-cluster.kubeconfig	

	kubectl create namespace mctc-system
	kubectl apply -f agent-manifests.yaml
	```