### PR TITLE
Sync agent multi resources

### DIFF
--- a/config/syncer/syncer.yaml
+++ b/config/syncer/syncer.yaml
@@ -22,6 +22,7 @@ spec:
         - -control-plane-config-namespace=mctc-system
         - -control-plane-config-name=control-plane-cluster-internal
         - -synced-resources=gateways.v1beta1.gateway.networking.k8s.io
+        - -synced-resources=secrets.v1
         image: syncer:latest
         imagePullPolicy: Never
         name: syncer

--- a/hack/make/syncer.make
+++ b/hack/make/syncer.make
@@ -13,7 +13,8 @@ run-syncer: manifests generate fmt vet install
 	    --health-probe-bind-address=:8087 \
 	    --control-plane-config-name=control-plane-cluster \
 	    --control-plane-config-namespace=mctc-system \
-	    --synced-resources=gateways.v1beta1.gateway.networking.k8s.io
+	    --synced-resources=gateways.v1beta1.gateway.networking.k8s.io \
+	    --synced-resources=secrets.v1
 
 .PHONY: docker-build-syncer
 docker-build-syncer: ## Build docker image with the syncer.

--- a/pkg/syncer/spec/controller.go
+++ b/pkg/syncer/spec/controller.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	controllerName                      = "mctc-spec-syncing-controller"
-	SyncerFinalizerNamePrefix           = "mctc-spec-syncer-finalizer-"
+	SyncerFinalizerNamePrefix           = "mctc-spec-syncer-finalizer/"
 	SyncerDeletionAnnotationPrefix      = "mctc-spec-syncer-deletion-timestamp-"
 	SyncerClusterStatusAnnotationPrefix = "mctc-spec-syncer-status-"
 	syncerApplyManager                  = "syncer"
@@ -209,7 +209,7 @@ func (c *Controller) ensureSyncerFinalizer(ctx context.Context, gvr schema.Group
 		upstreamFinalizers = append(upstreamFinalizers, SyncerFinalizerNamePrefix+c.syncTargetKey)
 		upstreamObjCopy.SetFinalizers(upstreamFinalizers)
 		if _, err := c.upstreamClient.Resource(gvr).Namespace(namespace).Update(ctx, upstreamObjCopy, metav1.UpdateOptions{}); err != nil {
-			logger.Error(err, "Failed adding finalizer on upstream upstreamresource")
+			logger.Error(err, "Failed adding finalizer on upstream resource")
 			return false, err
 		}
 		logger.Info("Updated upstream resource with syncer finalizer")


### PR DESCRIPTION
allow multiple resources to sync
allow core resources to sync

##verify
```
make local-setup MCTC_WORKLOAD_CLUSTERS_COUNT=1
export KUBECONFIG=./tmp/kubeconfigs/mctc-workload-1.kubeconfig
make kind-load-syncer
make deploy-syncer
export KUBECONFIG=./tmp/kubeconfigs/mctc-control-plane.kubeconfig
kubectl create ns mctc-tenant
kubectl create -f config/samples/secret.yaml -n mctc-tenant
kubectl annotate secret cluster1 mctc-sync-agent/all=true -n mctc-tenant
export KUBECONFIG=./tmp/kubeconfigs/mctc-workload-1.kubeconfig
kubectl get secret cluster1 -n mctc-downstream -o yaml
```