### PR TITLE
Improve MZ and record lookup for gateway reconciles

### DIFF
--- a/pkg/controllers/ingress/ingress.go
+++ b/pkg/controllers/ingress/ingress.go
@@ -45,7 +45,7 @@ const (
 type HostService interface {
 	EnsureManagedHost(ctx context.Context, t traffic.Interface) ([]*v1alpha1.DNSRecord, error)
 	AddEndPoints(ctx context.Context, t traffic.Interface, host string) error
-	RemoveEndpoints(ctx context.Context, t traffic.Interface) error
+	RemoveEndPoints(ctx context.Context, t traffic.Interface) error
 }
 
 type CertificateService interface {


### PR DESCRIPTION
closes #111 

Updates the gateway reconciler to build up a list of managed hosts which includes a reference to the managed zone which can service it, and the DNSRecord that will exist or just have been created for it.  Later in the reconciliation when adding endpoints, we can now explicitly tell it what DNSRecord to add the endpoints to for each managed host.

The reconcilation logic between ingress and gateways is currently quite different. Ingresses expects a single host to be generated for a suitable manged zone and gateways do a lookup of multiple associated hosts for a managed zone capable of serving each. To make things easier this PR separates the logic for the two inside the dns service since trying to make it work for both is counterintuitive as we will more than likley remove the current ingress logic eventually.